### PR TITLE
GPP smoothing parameters changed to 0.999

### DIFF
--- a/biogeophys/FatesPlantRespPhotosynthMod.F90
+++ b/biogeophys/FatesPlantRespPhotosynthMod.F90
@@ -925,11 +925,13 @@ contains
    ! quantum efficiency, used only for C4 (mol CO2 / mol photons) (index 0)
    real(r8),parameter,dimension(0:1) :: quant_eff = [0.05_r8,0.0_r8]
 
-   ! empirical curvature parameter for ac, aj photosynthesis co-limitation
+   ! empirical curvature parameter for ac, aj photosynthesis co-limitation. 
+   ! Changed theta_cj and theta_ip to 0.999 to effectively remove smoothing logic 
+   ! following Anthony Walker's findings from MAAT. 
    real(r8),parameter,dimension(0:1) :: theta_cj  = [0.999_r8,0.999_r8]
 
    ! empirical curvature parameter for ap photosynthesis co-limitation
-   real(r8),parameter :: theta_ip = 0.9999_r8
+   real(r8),parameter :: theta_ip = 0.999_r8
 
    associate( bb_slope  => EDPftvarcon_inst%BB_slope)    ! slope of BB relationship
 

--- a/biogeophys/FatesPlantRespPhotosynthMod.F90
+++ b/biogeophys/FatesPlantRespPhotosynthMod.F90
@@ -926,10 +926,10 @@ contains
    real(r8),parameter,dimension(0:1) :: quant_eff = [0.05_r8,0.0_r8]
 
    ! empirical curvature parameter for ac, aj photosynthesis co-limitation
-   real(r8),parameter,dimension(0:1) :: theta_cj  = [0.80_r8,0.98_r8]
+   real(r8),parameter,dimension(0:1) :: theta_cj  = [0.999_r8,0.999_r8]
 
    ! empirical curvature parameter for ap photosynthesis co-limitation
-   real(r8),parameter :: theta_ip = 0.95_r8
+   real(r8),parameter :: theta_ip = 0.9999_r8
 
    associate( bb_slope  => EDPftvarcon_inst%BB_slope)    ! slope of BB relationship
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:
Following findings in MAAT that the GPP smoothing routines drastically and illogically modify carbon fluxes, we changed both smoothing parameters to 0.999. This acts in lieu of removing the logic altogether.

### Collaborators:
Anthony Walker, Alistair Rogers, Ryan Knox, Charlie Koven. 

### Expectation of Answer Changes:
GPP is increased by around 20%. See:
https://github.com/NGEET/fates/issues/472 
for details. 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [Not necessarily! ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [x ] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [x] If answers were expected to change, evaluation was performed and provided


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

