### PR TITLE
bugfixes on indexing overflows

### DIFF
--- a/biogeochem/EDCanopyStructureMod.F90
+++ b/biogeochem/EDCanopyStructureMod.F90
@@ -1924,97 +1924,97 @@ contains
        currentPatch => sites(s)%oldest_patch
        c = fcolumn(s)
        do while(associated(currentPatch))
-          if(currentPatch%nocomp_pft_label.ne.0)then
-             ! only increase ifp for veg patches, not bareground (in SP mode)
+
+          if(currentPatch%nocomp_pft_label.ne.0)then  ! ignore the bare-ground-PFT patch entirely for these BC outs
+
              ifp = ifp+1
-          endif ! stay with ifp=0 for bareground patch.
-          if ( currentPatch%total_canopy_area-currentPatch%area > 0.000001_r8 ) then
-             write(fates_log(),*) 'ED: canopy area bigger than area',currentPatch%total_canopy_area ,currentPatch%area
-             currentPatch%total_canopy_area = currentPatch%area
-          endif
 
+             if ( currentPatch%total_canopy_area-currentPatch%area > 0.000001_r8 ) then
+                write(fates_log(),*) 'ED: canopy area bigger than area',currentPatch%total_canopy_area ,currentPatch%area
+                currentPatch%total_canopy_area = currentPatch%area
+             endif
 
-          if (associated(currentPatch%tallest)) then
-             bc_out(s)%htop_pa(ifp) = currentPatch%tallest%hite
-          else
-             ! FIX(RF,040113) - should this be a parameter for the minimum possible vegetation height?
-             bc_out(s)%htop_pa(ifp) = 0.1_r8
-          endif
+             if (associated(currentPatch%tallest)) then
+                bc_out(s)%htop_pa(ifp) = currentPatch%tallest%hite
+             else
+                ! FIX(RF,040113) - should this be a parameter for the minimum possible vegetation height?
+                bc_out(s)%htop_pa(ifp) = 0.1_r8
+             endif
 
-          bc_out(s)%hbot_pa(ifp) = max(0._r8, min(0.2_r8, bc_out(s)%htop_pa(ifp)- 1.0_r8))
-          ! Use leaf area weighting for all cohorts in the patch to define the characteristic
-          ! leaf width used by the HLM
-          ! ----------------------------------------------------------------------------
-          !           bc_out(s)%dleaf_pa(ifp) = 0.0_r8
-          !           if(currentPatch%lai>1.0e-9_r8) then
-          !              currentCohort => currentPatch%shortest
-          !              do while(associated(currentCohort))
-          !                 weight = min(1.0_r8,currentCohort%lai/currentPatch%lai)
-          !                 bc_out(s)%dleaf_pa(ifp) = bc_out(s)%dleaf_pa(ifp) + &
-          !                       EDPftvarcon_inst%dleaf(currentCohort%pft)*weight
-          !                 currentCohort => currentCohort%taller
-          !              enddo
-          !           end if
+             bc_out(s)%hbot_pa(ifp) = max(0._r8, min(0.2_r8, bc_out(s)%htop_pa(ifp)- 1.0_r8))
 
-          ! Roughness length and displacement height are not PFT properties, they are
-          ! properties of the canopy assemblage.  Defining this needs an appropriate model.
-          ! Right now z0 and d are pft level parameters.  For the time being we will just
-          ! use the 1st index until a suitable model is defined. (RGK 04-2017)
-          ! -----------------------------------------------------------------------------
-          bc_out(s)%z0m_pa(ifp)    = EDPftvarcon_inst%z0mr(1) * bc_out(s)%htop_pa(ifp)
-          bc_out(s)%displa_pa(ifp) = EDPftvarcon_inst%displar(1) * bc_out(s)%htop_pa(ifp)
-          bc_out(s)%dleaf_pa(ifp)  = EDPftvarcon_inst%dleaf(1)
+             ! Use leaf area weighting for all cohorts in the patch to define the characteristic
+             ! leaf width used by the HLM
+             ! ----------------------------------------------------------------------------
+             !           bc_out(s)%dleaf_pa(ifp) = 0.0_r8
+             !           if(currentPatch%lai>1.0e-9_r8) then
+             !              currentCohort => currentPatch%shortest
+             !              do while(associated(currentCohort))
+             !                 weight = min(1.0_r8,currentCohort%lai/currentPatch%lai)
+             !                 bc_out(s)%dleaf_pa(ifp) = bc_out(s)%dleaf_pa(ifp) + &
+             !                       EDPftvarcon_inst%dleaf(currentCohort%pft)*weight
+             !                 currentCohort => currentCohort%taller
+             !              enddo
+             !           end if
 
-          ! We are assuming here that grass is all located underneath tree canopies.
-          ! The alternative is to assume it is all spatial distinct from tree canopies.
-          ! In which case, the bare area would have to be reduced by the grass area...
-          ! currentPatch%total_canopy_area/currentPatch%area is fraction of this patch cover by plants
-          ! currentPatch%area/AREA is the fraction of the soil covered by this patch.
-          if(currentPatch%area.gt.0.0_r8)then
-             bc_out(s)%canopy_fraction_pa(ifp) = &
-                  min(1.0_r8,currentPatch%total_canopy_area/currentPatch%area)*(currentPatch%area/AREA)
-          else
-             bc_out(s)%canopy_fraction_pa(ifp) = 0.0_r8
-          endif
+             ! Roughness length and displacement height are not PFT properties, they are
+             ! properties of the canopy assemblage.  Defining this needs an appropriate model.
+             ! Right now z0 and d are pft level parameters.  For the time being we will just
+             ! use the 1st index until a suitable model is defined. (RGK 04-2017)
+             ! -----------------------------------------------------------------------------
+             bc_out(s)%z0m_pa(ifp)    = EDPftvarcon_inst%z0mr(1) * bc_out(s)%htop_pa(ifp)
+             bc_out(s)%displa_pa(ifp) = EDPftvarcon_inst%displar(1) * bc_out(s)%htop_pa(ifp)
+             bc_out(s)%dleaf_pa(ifp)  = EDPftvarcon_inst%dleaf(1)
 
-          bare_frac_area = (1.0_r8 - min(1.0_r8,currentPatch%total_canopy_area/currentPatch%area)) * &
-               (currentPatch%area/AREA)
+             ! We are assuming here that grass is all located underneath tree canopies.
+             ! The alternative is to assume it is all spatial distinct from tree canopies.
+             ! In which case, the bare area would have to be reduced by the grass area...
+             ! currentPatch%total_canopy_area/currentPatch%area is fraction of this patch cover by plants
+             ! currentPatch%area/AREA is the fraction of the soil covered by this patch.
 
-          total_patch_area = total_patch_area + bc_out(s)%canopy_fraction_pa(ifp) + bare_frac_area
+             if(currentPatch%area.gt.0.0_r8)then
+                bc_out(s)%canopy_fraction_pa(ifp) = &
+                     min(1.0_r8,currentPatch%total_canopy_area/currentPatch%area)*(currentPatch%area/AREA)
+             else
+                bc_out(s)%canopy_fraction_pa(ifp) = 0.0_r8
+             endif
 
-          total_canopy_area = total_canopy_area + bc_out(s)%canopy_fraction_pa(ifp)
+             bare_frac_area = (1.0_r8 - min(1.0_r8,currentPatch%total_canopy_area/currentPatch%area)) * &
+                  (currentPatch%area/AREA)
 
-          bc_out(s)%nocomp_pft_label_pa(ifp) = currentPatch%nocomp_pft_label
+             total_patch_area = total_patch_area + bc_out(s)%canopy_fraction_pa(ifp) + bare_frac_area
 
-          ! Calculate area indices for output boundary to HLM
-          ! It is assumed that cpatch%canopy_area_profile and cpat%xai_profiles
-          ! have been updated (ie ed_leaf_area_profile has been called since dynamics has been called)
+             total_canopy_area = total_canopy_area + bc_out(s)%canopy_fraction_pa(ifp)
 
-          bc_out(s)%elai_pa(ifp) = calc_areaindex(currentPatch,'elai')
-          bc_out(s)%tlai_pa(ifp) = calc_areaindex(currentPatch,'tlai')
-          bc_out(s)%esai_pa(ifp) = calc_areaindex(currentPatch,'esai')
-          bc_out(s)%tsai_pa(ifp) = calc_areaindex(currentPatch,'tsai')
+             bc_out(s)%nocomp_pft_label_pa(ifp) = currentPatch%nocomp_pft_label
 
-          !if(debug) then
-          !   write(fates_log(),*) 'ifp: ', ifp
-          !   write(fates_log(),*) 'bc_out(s)%elai_pa(ifp): ', bc_out(s)%elai_pa(ifp)
-          !   write(fates_log(),*) 'bc_out(s)%tlai_pa(ifp): ', bc_out(s)%tlai_pa(ifp)
-          !   write(fates_log(),*) 'bc_out(s)%esai_pa(ifp): ', bc_out(s)%esai_pa(ifp)
-          !   write(fates_log(),*) 'bc_out(s)%tsai_pa(ifp): ', bc_out(s)%tsai_pa(ifp)
-          !end if
+             ! Calculate area indices for output boundary to HLM
+             ! It is assumed that cpatch%canopy_area_profile and cpat%xai_profiles
+             ! have been updated (ie ed_leaf_area_profile has been called since dynamics has been called)
 
-          ! Fraction of vegetation free of snow. This is used to flag those
-          ! patches which shall under-go photosynthesis
-          ! INTERF-TODO: we may want to stop using frac_veg_nosno_alb and let
-          ! FATES internal variables decide if photosynthesis is possible
-          ! we are essentially calculating it inside FATES to tell the
-          ! host to tell itself when to do things (circuitous). Just have
-          ! to determine where else it is used
+             bc_out(s)%elai_pa(ifp) = calc_areaindex(currentPatch,'elai')
+             bc_out(s)%tlai_pa(ifp) = calc_areaindex(currentPatch,'tlai')
+             bc_out(s)%esai_pa(ifp) = calc_areaindex(currentPatch,'esai')
+             bc_out(s)%tsai_pa(ifp) = calc_areaindex(currentPatch,'tsai')
 
-          if ((bc_out(s)%elai_pa(ifp) + bc_out(s)%esai_pa(ifp)) > 0._r8) then
-             bc_out(s)%frac_veg_nosno_alb_pa(ifp) = 1.0_r8
-          else
-             bc_out(s)%frac_veg_nosno_alb_pa(ifp) = 0.0_r8
+             ! Fraction of vegetation free of snow. This is used to flag those
+             ! patches which shall under-go photosynthesis
+             ! INTERF-TODO: we may want to stop using frac_veg_nosno_alb and let
+             ! FATES internal variables decide if photosynthesis is possible
+             ! we are essentially calculating it inside FATES to tell the
+             ! host to tell itself when to do things (circuitous). Just have
+             ! to determine where else it is used
+
+             if ((bc_out(s)%elai_pa(ifp) + bc_out(s)%esai_pa(ifp)) > 0._r8) then
+                bc_out(s)%frac_veg_nosno_alb_pa(ifp) = 1.0_r8
+             else
+                bc_out(s)%frac_veg_nosno_alb_pa(ifp) = 0.0_r8
+             end if
+
+          else  ! nocomp or SP, and currentPatch%nocomp_pft_label .eq. 0
+             
+             total_patch_area = total_patch_area + currentPatch%area/AREA
+             
           end if
           currentPatch => currentPatch%younger
        end do
@@ -2040,10 +2040,7 @@ contains
              if(currentPatch%nocomp_pft_label.ne.0)then ! for vegetated patches only
                 ifp = ifp+1
                 bc_out(s)%canopy_fraction_pa(ifp) = bc_out(s)%canopy_fraction_pa(ifp)/total_patch_area
-             else ! for the bareground patch (in SP mode).
-                bc_out(s)%canopy_fraction_pa(ifp) =0.0_r8
              endif ! veg patch
-
 
              currentPatch => currentPatch%younger
           end do

--- a/main/EDInitMod.F90
+++ b/main/EDInitMod.F90
@@ -133,7 +133,12 @@ contains
     allocate(site_in%dz_soil(site_in%nlevsoil))
     allocate(site_in%z_soil(site_in%nlevsoil))
 
-    allocate(site_in%area_pft(1:numpft))      ! Changing to zero indexing
+    if (hlm_use_nocomp .eq. itrue) then
+       allocate(site_in%area_pft(0:numpft))
+    else  ! SP and nocomp require a bare-ground patch.
+       allocate(site_in%area_pft(1:numpft))  
+    endif
+
     allocate(site_in%use_this_pft(1:numpft))
 
     ! SP mode
@@ -331,7 +336,7 @@ contains
                    write(fates_log(),*)  'removing small pft patches',s,ft,sites(s)%area_pft(ft)
                    sites(s)%area_pft(ft)=0.0_r8
                    ! remove tiny patches to prevent numerical errors in terminate patches
-              endif
+                endif
                 if(sites(s)%area_pft(ft).lt.0._r8)then
                    write(fates_log(),*) 'negative area',s,ft,sites(s)%area_pft(ft)
                    call endrun(msg=errMsg(sourcefile, __LINE__))
@@ -344,8 +349,9 @@ contains
              ! the bare ground will no longer be proscribed and should emerge from FATES
              ! this may or may not be the right way to deal with this?
 
-             if(hlm_use_sp.eq.ifalse)then ! when not in SP mode, subsume bare ground evenly into the existing patches.
-                !n.b. that it might be better if nocomp mode used the same bare groud logic as SP mode.
+             if(hlm_use_nocomp.eq.ifalse)then ! when not in nocomp (i.e. or SP) mode, 
+                ! subsume bare ground evenly into the existing patches.
+
                 sumarea = sum(sites(s)%area_pft(1:numpft))
                 do ft =  1,numpft
                    if(sumarea.gt.0._r8)then
@@ -356,23 +362,23 @@ contains
                       ! all pfts and let the model figure out whether land should be bare or not.
                    end if
                 end do !ft
-             else ! for sp mode, assert a bare ground patch
+             else ! for sp and nocomp mode, assert a bare ground patch if needed
                 sumarea = sum(sites(s)%area_pft(1:numpft))
 
                ! In all the other FATES modes, bareground is the area in which plants
-               ! do not grow of their own accord. In SP mod wweassert that the  canopy is full for
-               ! each PFT patche. Thus,  we also need to assert a bare ground area in
-               !  order to not have all of the ground filled by leaves.
+               ! do not grow of their own accord. In SP mode we assert that the canopy is full for
+               ! each PFT patch. Thus, we also need to assert a bare ground area in
+               ! order to not have all of the ground filled by leaves.
 
                ! Further to that, one could calculate bare ground as the remaining area when
                ! all fhe canopies are accounted for, but this means we don't pass balance checks
-               !  on canopy are inside FATES, and so in SP mode, we define the bare groud
+               ! on canopy are inside FATES, and so in SP mode, we define the bare groud
                ! patch as having a PFT identifier as zero.
 
                 if(sumarea.lt.area)then !make some bare ground
-                   sites(s)%area_bareground = area - sumarea
+                   sites(s)%area_pft(0) = area - sumarea
                 else
-                   sites(s)%area_bareground = 0.0_r8
+                   sites(s)%area_pft(0) = 0.0_r8
                 end if
              end if !sp mode
           end if !fixed biogeog
@@ -482,7 +488,6 @@ contains
           if(hlm_use_nocomp.eq.itrue)then
              num_new_patches = numpft
              if(hlm_use_sp.eq.itrue)then
-                num_new_patches = numpft + 1 ! bare ground patch in SP mode.
                 start_patch = 0 ! start at the bare ground patch
              endif
              !           allocate(newppft(numpft))
@@ -515,11 +520,6 @@ contains
              else  ! The default case is initialized w/ one patch with the area of the whole site.
                 newparea = area
              end if  !nocomp mode
-
-             if(hlm_use_sp.eq.itrue.and.n.eq.0)then ! bare ground patch
-                newparea = sites(s)%area_bareground
-                nocomp_pft = 0
-             end if
 
              if(newparea.gt.0._r8)then ! Stop patches being initilialized when PFT not present in nocomop mode
                 allocate(newp)

--- a/main/EDInitMod.F90
+++ b/main/EDInitMod.F90
@@ -487,10 +487,8 @@ contains
           start_patch = 1   ! start at the first vegetated patch
           if(hlm_use_nocomp.eq.itrue)then
              num_new_patches = numpft
-             if(hlm_use_sp.eq.itrue)then
-                start_patch = 0 ! start at the bare ground patch
-             endif
-             !           allocate(newppft(numpft))
+             start_patch = 0 ! start at the bare ground patch
+             !
           else !default
              num_new_patches = 1
           end if !nocomp

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -701,8 +701,6 @@ module EDTypesMod
      real(r8), allocatable :: sp_tsai(:)                      ! target TSAI per FATES pft
      real(r8), allocatable :: sp_htop(:)                      ! target HTOP per FATES pft
      
-     real(r8) :: area_bareground                               ! in SP mode we assert a bare ground fraction
-
      ! Mass Balance (allocation for each element)
 
      type(site_massbal_type), pointer :: mass_balance(:)


### PR DESCRIPTION
the prior code was making scientific sense but not completing when edbug was set to true, because it was trying to write to index zero for both some internal arrays as well as the various bc_out arrays, all of which were indexed from 1:numpfts.  To address this, I made the internal arrays indexed from 0:numpfts when SP or nocomp were enabled, and ignored completely the bare-ground PFTs when writing to the bc_out variables.  I think this is the correct thing to do since the way that the bc_out variables are indexed in the HLM is like this:

          do ifp = 1, this%fates(nc)%sites(s)%youngest_patch%patchno
             ! for the vegetated patches                                                                                                                                                             
             p = ifp+col%patchi(c)

where `patchi` refers to the bare-ground patch on that column so it's bare-ground-ness is already taken into account.

anyway this doesn't fix our failure to pass exact-restart tests but does fix what was I think a buffer overflow that was leading to the instability that we were seeing before.

<!--- Provide a general summary of your changes in the Title above -->

### Description:
<!--- Describe your changes in detail -->
<!--- please add issue number if one exists -->

### Collaborators:
<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->

### Expectation of Answer Changes:
<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

