### PR TITLE
new fire restart variables

### DIFF
--- a/main/FatesRestartInterfaceMod.F90
+++ b/main/FatesRestartInterfaceMod.F90
@@ -36,6 +36,7 @@ module FatesRestartInterfaceMod
   use FatesLitterMod,          only : litter_type
   use FatesLitterMod,          only : ncwd
   use FatesLitterMod,          only : ndcmpy
+  use EDTypesMod,              only : nfsc
   use PRTGenericMod,           only : prt_global
   use PRTGenericMod,           only : num_elements
 
@@ -174,6 +175,8 @@ module FatesRestartInterfaceMod
   integer :: ir_lfines_frag_litt
   integer :: ir_rfines_frag_litt
 
+  integer :: ir_scorch_ht_pa_pft
+  integer :: ir_litter_moisture_pa_nfsc
 
   ! Site level
   integer :: ir_watermem_siwm
@@ -920,6 +923,13 @@ contains
          long_name='are of the ED patch', units='m2', flushval = flushzero, &
          hlms='CLM:ALM', initialize=initialize_variables, ivar=ivar, index = ir_area_pa )
 
+    call this%set_restart_var(vname='fates_scorch_ht_pa_pft', vtype=cohort_r8, &
+         long_name='scorch height', units='m', flushval = flushzero, &
+         hlms='CLM:ALM', initialize=initialize_variables, ivar=ivar, index = ir_scorch_ht_pa_pft)
+
+    call this%set_restart_var(vname='fates_litter_moisture_pa_nfsc', vtype=cohort_r8, &
+         long_name='scorch height', units='m', flushval = flushzero, &
+         hlms='CLM:ALM', initialize=initialize_variables, ivar=ivar, index = ir_litter_moisture_pa_nfsc)
 
     ! Site Level Diagnostics over multiple nutrients
 
@@ -1974,6 +1984,18 @@ contains
                       ,io_idx_co,cohortsperpatch
              endif
 
+             io_idx_pa_pft  = io_idx_co_1st
+             do i = 1,numpft
+                this%rvars(ir_scorch_ht_pa_pft)%r81d(io_idx_pa_pft) = cpatch%scorch_ht(i)
+                io_idx_pa_pft      = io_idx_pa_pft + 1
+             end do
+
+             io_idx_pa_cwd  = io_idx_co_1st
+             do i = 1,nfsc
+                this%rvars(ir_litter_moisture_pa_nfsc)%r81d(io_idx_pa_cwd) = cpatch%litter_moisture(i)
+                io_idx_pa_cwd      = io_idx_pa_cwd + 1
+             end do
+
              ! --------------------------------------------------------------------------
              ! Send litter to the restart arrays
              ! Each element has its own variable, so we have to make sure
@@ -2760,6 +2782,18 @@ contains
                 write(fates_log(),*) 'CVTL III ' &
                      ,io_idx_co,cohortsperpatch
              endif
+
+             io_idx_pa_pft  = io_idx_co_1st
+             do i = 1,numpft
+                cpatch%scorch_ht(i) = this%rvars(ir_scorch_ht_pa_pft)%r81d(io_idx_pa_pft)
+                io_idx_pa_pft      = io_idx_pa_pft + 1
+             end do
+
+             io_idx_pa_cwd  = io_idx_co_1st
+             do i = 1,nfsc
+                cpatch%litter_moisture(i) = this%rvars(ir_litter_moisture_pa_nfsc)%r81d(io_idx_pa_cwd)
+                io_idx_pa_cwd      = io_idx_pa_cwd + 1
+             end do
 
              ! --------------------------------------------------------------------------
              ! Pull litter from the restart arrays


### PR DESCRIPTION
added fire variables to allow nocomp to pass restart comparison with fire on.  The nocomp passes B4B for me now with these changes. I have no idea why this only comes up in nocomp and not in general when we run FATES with fire.

<!--- Provide a general summary of your changes in the Title above -->

### Description:
<!--- Describe your changes in detail -->
<!--- please add issue number if one exists -->

### Collaborators:
<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->

### Expectation of Answer Changes:
<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

