### PR TITLE
Add new FATES crop PFT and HLM PFTs

### DIFF
--- a/parameter_files/fates_params_default.cdl
+++ b/parameter_files/fates_params_default.cdl
@@ -1,4 +1,4 @@
-fates_params_sci.1.88.6_api.42.0.0_14pft_nor_sci3_api1_c260209 {
+netcdf fates_params_sci.1.88.6_api.42.0.0_14pft_nor_sci3_api1_c260209 {
 dimensions:
 	fates_NCWD = 4 ;
 	fates_history_age_bins = 7 ;

--- a/parameter_files/fates_params_default.cdl
+++ b/parameter_files/fates_params_default.cdl
@@ -1,4 +1,4 @@
-netcdf fates_params_sci.1.88.6_api.42.0.0_14pft_nor_sci3_api1_c260209 {
+netcdf fates_params_default_tmp {
 dimensions:
 	fates_NCWD = 4 ;
 	fates_history_age_bins = 7 ;
@@ -6,54 +6,18 @@ dimensions:
 	fates_history_damage_bins = 2 ;
 	fates_history_height_bins = 6 ;
 	fates_history_size_bins = 13 ;
-	fates_hlm_pftno = 14 ;
+	fates_hlm_pftno = 16 ;
 	fates_hydr_organs = 4 ;
 	fates_landuseclass = 5 ;
 	fates_leafage_class = 1 ;
 	fates_litterclass = 6 ;
-	fates_pft = 14 ;
+	fates_pft = 15 ;
 	fates_plant_organs = 4 ;
 	fates_string_length = 60 ;
 variables:
-	double fates_history_ageclass_bin_edges(fates_history_age_bins) ;
-		fates_history_ageclass_bin_edges:units = "yr" ;
-		fates_history_ageclass_bin_edges:long_name = "Lower edges for age class bins used in age-resolved patch history output" ;
-	double fates_history_coageclass_bin_edges(fates_history_coage_bins) ;
-		fates_history_coageclass_bin_edges:units = "years" ;
-		fates_history_coageclass_bin_edges:long_name = "Lower edges for cohort age class bins used in cohort age resolved history output" ;
-	double fates_history_height_bin_edges(fates_history_height_bins) ;
-		fates_history_height_bin_edges:units = "m" ;
-		fates_history_height_bin_edges:long_name = "Lower edges for height bins used in height-resolved history output" ;
-	double fates_history_damage_bin_edges(fates_history_damage_bins) ;
-		fates_history_damage_bin_edges:units = "% crown loss" ;
-		fates_history_damage_bin_edges:long_name = "Lower edges for damage class bins used in cohort history output" ;
-	double fates_history_sizeclass_bin_edges(fates_history_size_bins) ;
-		fates_history_sizeclass_bin_edges:units = "cm" ;
-		fates_history_sizeclass_bin_edges:long_name = "Lower edges for DBH size class bins used in size-resolved cohort history output" ;
-	double fates_alloc_organ_id(fates_plant_organs) ;
-		fates_alloc_organ_id:units = "unitless" ;
-		fates_alloc_organ_id:long_name = "This is the global index that the organ in this file is associated with, values match those in parteh/PRTGenericMod.F90" ;
-	double fates_hydro_htftype_node(fates_hydr_organs) ;
-		fates_hydro_htftype_node:units = "unitless" ;
-		fates_hydro_htftype_node:long_name = "Switch that defines the hydraulic transfer functions for each organ." ;
 	char fates_pftname(fates_pft, fates_string_length) ;
 		fates_pftname:units = "unitless - string" ;
 		fates_pftname:long_name = "Description of plant type" ;
-	char fates_hydro_organ_name(fates_hydr_organs, fates_string_length) ;
-		fates_hydro_organ_name:units = "unitless - string" ;
-		fates_hydro_organ_name:long_name = "Name of plant hydraulics organs (DONT CHANGE, order matches media list in FatesHydraulicsMemMod.F90)" ;
-	char fates_alloc_organ_name(fates_plant_organs, fates_string_length) ;
-		fates_alloc_organ_name:units = "unitless - string" ;
-		fates_alloc_organ_name:long_name = "Name of plant organs (with alloc_organ_id, must match PRTGenericMod.F90)" ;
-	char fates_landuseclass_name(fates_landuseclass, fates_string_length) ;
-		fates_landuseclass_name:units = "unitless - string" ;
-		fates_landuseclass_name:long_name = "Name of the land use classes, for variables associated with dimension fates_landuseclass" ;
-	char fates_litterclass_name(fates_litterclass, fates_string_length) ;
-		fates_litterclass_name:units = "unitless - string" ;
-		fates_litterclass_name:long_name = "Name of the litter classes, for variables associated with dimension fates_litterclass" ;
-	double fates_alloc_organ_priority(fates_plant_organs, fates_pft) ;
-		fates_alloc_organ_priority:units = "index" ;
-		fates_alloc_organ_priority:long_name = "Priority level for allocation, 1: replaces turnover from storage, 2: same priority as storage use/replacement, 3: ascending in order of least importance" ;
 	double fates_alloc_storage_cushion(fates_pft) ;
 		fates_alloc_storage_cushion:units = "fraction" ;
 		fates_alloc_storage_cushion:long_name = "maximum size of storage C pool, relative to maximum size of leaf C pool" ;
@@ -228,12 +192,6 @@ variables:
 	double fates_cnp_store_ovrflw_frac(fates_pft) ;
 		fates_cnp_store_ovrflw_frac:units = "fraction" ;
 		fates_cnp_store_ovrflw_frac:long_name = "size of overflow storage (for excess C,N or P) as a fraction of storage target" ;
-	double fates_cnp_turnover_nitr_retrans(fates_plant_organs, fates_pft) ;
-		fates_cnp_turnover_nitr_retrans:units = "fraction" ;
-		fates_cnp_turnover_nitr_retrans:long_name = "retranslocation (reabsorbtion) fraction of nitrogen in turnover of scenescing tissues" ;
-	double fates_cnp_turnover_phos_retrans(fates_plant_organs, fates_pft) ;
-		fates_cnp_turnover_phos_retrans:units = "fraction" ;
-		fates_cnp_turnover_phos_retrans:long_name = "retranslocation (reabsorbtion) fraction of phosphorus in turnover of scenescing tissues" ;
 	double fates_cnp_vmax_nh4(fates_pft) ;
 		fates_cnp_vmax_nh4:units = "gN/gC/s" ;
 		fates_cnp_vmax_nh4:long_name = "maximum (potential) uptake rate of NH4 per gC of fineroot biomass (see main/EDPftvarcon.F90 vmax_nh4 for usage)" ;
@@ -294,39 +252,15 @@ variables:
 	double fates_hydro_avuln_gs(fates_pft) ;
 		fates_hydro_avuln_gs:units = "unitless" ;
 		fates_hydro_avuln_gs:long_name = "shape parameter for stomatal control of water vapor exiting leaf" ;
-	double fates_hydro_avuln_node(fates_hydr_organs, fates_pft) ;
-		fates_hydro_avuln_node:units = "unitless" ;
-		fates_hydro_avuln_node:long_name = "xylem vulnerability curve shape parameter" ;
-	double fates_hydro_epsil_node(fates_hydr_organs, fates_pft) ;
-		fates_hydro_epsil_node:units = "MPa" ;
-		fates_hydro_epsil_node:long_name = "bulk elastic modulus" ;
-	double fates_hydro_fcap_node(fates_hydr_organs, fates_pft) ;
-		fates_hydro_fcap_node:units = "unitless" ;
-		fates_hydro_fcap_node:long_name = "fraction of non-residual water that is capillary in source" ;
 	double fates_hydro_k_lwp(fates_pft) ;
 		fates_hydro_k_lwp:units = "unitless" ;
 		fates_hydro_k_lwp:long_name = "inner leaf humidity scaling coefficient" ;
-	double fates_hydro_kmax_node(fates_hydr_organs, fates_pft) ;
-		fates_hydro_kmax_node:units = "kg/MPa/m/s" ;
-		fates_hydro_kmax_node:long_name = "maximum xylem conductivity per unit conducting xylem area" ;
 	double fates_hydro_p50_gs(fates_pft) ;
 		fates_hydro_p50_gs:units = "MPa" ;
 		fates_hydro_p50_gs:long_name = "water potential at 50% loss of stomatal conductance" ;
-	double fates_hydro_p50_node(fates_hydr_organs, fates_pft) ;
-		fates_hydro_p50_node:units = "MPa" ;
-		fates_hydro_p50_node:long_name = "xylem water potential at 50% loss of conductivity" ;
 	double fates_hydro_p_taper(fates_pft) ;
 		fates_hydro_p_taper:units = "unitless" ;
 		fates_hydro_p_taper:long_name = "xylem taper exponent" ;
-	double fates_hydro_pinot_node(fates_hydr_organs, fates_pft) ;
-		fates_hydro_pinot_node:units = "MPa" ;
-		fates_hydro_pinot_node:long_name = "osmotic potential at full turgor" ;
-	double fates_hydro_pitlp_node(fates_hydr_organs, fates_pft) ;
-		fates_hydro_pitlp_node:units = "MPa" ;
-		fates_hydro_pitlp_node:long_name = "turgor loss point" ;
-	double fates_hydro_resid_node(fates_hydr_organs, fates_pft) ;
-		fates_hydro_resid_node:units = "cm3/cm3" ;
-		fates_hydro_resid_node:long_name = "residual water conent" ;
 	double fates_hydro_rfrac_stem(fates_pft) ;
 		fates_hydro_rfrac_stem:units = "fraction" ;
 		fates_hydro_rfrac_stem:long_name = "fraction of total tree resistance from troot to canopy" ;
@@ -336,18 +270,9 @@ variables:
 	double fates_hydro_srl(fates_pft) ;
 		fates_hydro_srl:units = "m g-1" ;
 		fates_hydro_srl:long_name = "specific root length" ;
-	double fates_hydro_thetas_node(fates_hydr_organs, fates_pft) ;
-		fates_hydro_thetas_node:units = "cm3/cm3" ;
-		fates_hydro_thetas_node:long_name = "saturated water content" ;
-	double fates_hydro_vg_alpha_node(fates_hydr_organs, fates_pft) ;
-		fates_hydro_vg_alpha_node:units = "MPa-1" ;
-		fates_hydro_vg_alpha_node:long_name = "(used if hydr_htftype_node = 2), capillary length parameter in van Genuchten model" ;
-	double fates_hydro_vg_m_node(fates_hydr_organs, fates_pft) ;
-		fates_hydro_vg_m_node:units = "unitless" ;
-		fates_hydro_vg_m_node:long_name = "(used if hydr_htftype_node = 2),m in van Genuchten 1980 model, 2nd pore size distribution parameter" ;
-	double fates_hydro_vg_n_node(fates_hydr_organs, fates_pft) ;
-		fates_hydro_vg_n_node:units = "unitless" ;
-		fates_hydro_vg_n_node:long_name = "(used if hydr_htftype_node = 2),n in van Genuchten 1980 model, pore size distribution parameter" ;
+	double fates_init_seed(fates_pft) ;
+		fates_init_seed:units = "kg/m2" ;
+		fates_init_seed:long_name = "initial seed pool (only applied)" ;
 	double fates_landuse_grazing_palatability(fates_pft) ;
 		fates_landuse_grazing_palatability:units = "unitless 0-1" ;
 		fates_landuse_grazing_palatability:long_name = "Relative intensity of leaf grazing/browsing per PFT" ;
@@ -399,9 +324,6 @@ variables:
 	double fates_leaf_stomatal_slope_medlyn(fates_pft) ;
 		fates_leaf_stomatal_slope_medlyn:units = "KPa**0.5" ;
 		fates_leaf_stomatal_slope_medlyn:long_name = "stomatal slope parameter, as per Medlyn" ;
-	double fates_leaf_vcmax25top(fates_leafage_class, fates_pft) ;
-		fates_leaf_vcmax25top:units = "umol CO2/m^2/s" ;
-		fates_leaf_vcmax25top:long_name = "maximum carboxylation rate of Rub. at 25C, canopy top" ;
 	double fates_leaf_vcmaxha(fates_pft) ;
 		fates_leaf_vcmaxha:units = "J/mol" ;
 		fates_leaf_vcmaxha:long_name = "activation energy for vcmax. NOTE: if fates_leaf_photo_tempsens_model=2 then these values are NOT USED" ;
@@ -555,9 +477,6 @@ variables:
 	double fates_recruit_init_nocomp(fates_pft) ;
 		fates_recruit_init_nocomp:units = "stems/m2 or dbh cm" ;
 		fates_recruit_init_nocomp:long_name = "initial seedling density or initial size of seedlings (if negative) in nocomp mode" ;
-	double fates_init_seed(fates_pft) ;
-		fates_init_seed:units = "kg/m2" ;
-		fates_init_seed:long_name = "initial seed pool (only applied)" ;
 	double fates_recruit_prescribed_rate(fates_pft) ;
 		fates_recruit_prescribed_rate:units = "n/yr" ;
 		fates_recruit_prescribed_rate:long_name = "recruitment rate for prescribed physiology mode" ;
@@ -588,12 +507,6 @@ variables:
 	double fates_seed_dispersal_pdf_shape(fates_pft) ;
 		fates_seed_dispersal_pdf_shape:units = "unitless" ;
 		fates_seed_dispersal_pdf_shape:long_name = "seed dispersal probability density function shape parameter, B, Table 1 Bullock et al 2016" ;
-	double fates_stoich_nitr(fates_plant_organs, fates_pft) ;
-		fates_stoich_nitr:units = "gN/gC" ;
-		fates_stoich_nitr:long_name = "target nitrogen concentration (ratio with carbon) of organs" ;
-	double fates_stoich_phos(fates_plant_organs, fates_pft) ;
-		fates_stoich_phos:units = "gP/gC" ;
-		fates_stoich_phos:long_name = "target phosphorus concentration (ratio with carbon) of organs" ;
 	double fates_trim_inc(fates_pft) ;
 		fates_trim_inc:units = "m2/m2" ;
 		fates_trim_inc:long_name = "Arbitrary incremental change in trimming function." ;
@@ -669,33 +582,39 @@ variables:
 	double fates_turnover_fnrt(fates_pft) ;
 		fates_turnover_fnrt:units = "yr" ;
 		fates_turnover_fnrt:long_name = "root longevity (alternatively, turnover time)" ;
-	double fates_turnover_leaf_canopy(fates_leafage_class, fates_pft) ;
-		fates_turnover_leaf_canopy:units = "yr" ;
-		fates_turnover_leaf_canopy:long_name = "Leaf longevity (ie turnover timescale) of canopy plants. For drought-deciduous PFTs, this also indicates the maximum length of the growing (i.e., leaves on) season." ;
-	double fates_turnover_leaf_ustory(fates_leafage_class, fates_pft) ;
-		fates_turnover_leaf_ustory:units = "yr" ;
-		fates_turnover_leaf_ustory:long_name = "Leaf longevity (ie turnover timescale) of understory plants." ;
 	double fates_turnover_senleaf_fdrought(fates_pft) ;
 		fates_turnover_senleaf_fdrought:units = "unitless[0-1]" ;
 		fates_turnover_senleaf_fdrought:long_name = "multiplication factor for leaf longevity of senescent leaves during drought" ;
+	double fates_voc_pftindex(fates_pft) ;
+		fates_voc_pftindex:units = "Integer PFT index" ;
+		fates_voc_pftindex:long_name = "integer index for MEGAN PFT definitions" ;
+	double fates_wesley_pft_index_fordrydep(fates_pft) ;
+		fates_wesley_pft_index_fordrydep:units = "integer index" ;
+		fates_wesley_pft_index_fordrydep:long_name = "index to map from fates pfts into the wesley pft space used to determing dry deposition veolcity." ;
 	double fates_wood_density(fates_pft) ;
 		fates_wood_density:units = "g/cm3" ;
 		fates_wood_density:long_name = "mean density of woody tissue in plant" ;
 	double fates_woody(fates_pft) ;
 		fates_woody:units = "logical flag" ;
 		fates_woody:long_name = "Binary woody lifeform flag" ;
-	double fates_voc_pftindex(fates_pft) ;
-		fates_voc_pftindex:units = "Integer PFT index" ;
-		fates_voc_pftindex:long_name = "integer index for MEGAN PFT definitions" ;
 	double fates_hlm_pft_map(fates_hlm_pftno, fates_pft) ;
 		fates_hlm_pft_map:units = "area fraction" ;
 		fates_hlm_pft_map:long_name = "In fixed biogeog mode, fraction of HLM area associated with each FATES PFT" ;
-	double fates_wesley_pft_index_fordrydep(fates_pft) ;
-		fates_wesley_pft_index_fordrydep:units = "integer index" ;
-		fates_wesley_pft_index_fordrydep:long_name = "index to map from fates pfts into the wesley pft space used to determing dry deposition veolcity." ;
+	double fates_history_sizeclass_bin_edges(fates_history_size_bins) ;
+		fates_history_sizeclass_bin_edges:units = "cm" ;
+		fates_history_sizeclass_bin_edges:long_name = "Lower edges for DBH size class bins used in size-resolved cohort history output" ;
+	double fates_history_ageclass_bin_edges(fates_history_age_bins) ;
+		fates_history_ageclass_bin_edges:units = "yr" ;
+		fates_history_ageclass_bin_edges:long_name = "Lower edges for age class bins used in age-resolved patch history output" ;
+	char fates_litterclass_name(fates_litterclass, fates_string_length) ;
+		fates_litterclass_name:units = "unitless - string" ;
+		fates_litterclass_name:long_name = "Name of the litter classes, for variables associated with dimension fates_litterclass" ;
 	double fates_fire_FBD(fates_litterclass) ;
 		fates_fire_FBD:units = "kg Biomass/m3" ;
 		fates_fire_FBD:long_name = "fuel bulk density" ;
+	double fates_fire_SAV(fates_litterclass) ;
+		fates_fire_SAV:units = "cm-1" ;
+		fates_fire_SAV:long_name = "fuel surface area to volume ratio" ;
 	double fates_fire_low_moisture_Coeff(fates_litterclass) ;
 		fates_fire_low_moisture_Coeff:units = "NA" ;
 		fates_fire_low_moisture_Coeff:long_name = "spitfire parameter, equation B1 Thonicke et al 2010" ;
@@ -714,15 +633,15 @@ variables:
 	double fates_fire_min_moisture(fates_litterclass) ;
 		fates_fire_min_moisture:units = "NA" ;
 		fates_fire_min_moisture:long_name = "spitfire litter moisture threshold to be considered very dry" ;
-	double fates_fire_SAV(fates_litterclass) ;
-		fates_fire_SAV:units = "cm-1" ;
-		fates_fire_SAV:long_name = "fuel surface area to volume ratio" ;
 	double fates_frag_maxdecomp(fates_litterclass) ;
 		fates_frag_maxdecomp:units = "yr-1" ;
 		fates_frag_maxdecomp:long_name = "maximum rate of litter & CWD transfer from non-decomposing class into decomposing class" ;
-	double fates_frag_cwd_frac(fates_NCWD) ;
-		fates_frag_cwd_frac:units = "fraction" ;
-		fates_frag_cwd_frac:long_name = "fraction of woody (bdead+bsw) biomass destined for CWD pool" ;
+	double fates_history_height_bin_edges(fates_history_height_bins) ;
+		fates_history_height_bin_edges:units = "m" ;
+		fates_history_height_bin_edges:long_name = "Lower edges for height bins used in height-resolved history output" ;
+	char fates_landuseclass_name(fates_landuseclass, fates_string_length) ;
+		fates_landuseclass_name:units = "unitless - string" ;
+		fates_landuseclass_name:long_name = "Name of the land use classes, for variables associated with dimension fates_landuseclass" ;
 	double fates_landuse_crop_lu_pft_vector(fates_landuseclass) ;
 		fates_landuse_crop_lu_pft_vector:units = "NA" ;
 		fates_landuse_crop_lu_pft_vector:long_name = "the FATES PFT index to use on a given crop land-use type (dummy value of -999 for non-crop types)" ;
@@ -735,6 +654,87 @@ variables:
 	double fates_maxpatches_by_landuse(fates_landuseclass) ;
 		fates_maxpatches_by_landuse:units = "count" ;
 		fates_maxpatches_by_landuse:long_name = "maximum number of patches per site on each land use type" ;
+	char fates_alloc_organ_name(fates_plant_organs, fates_string_length) ;
+		fates_alloc_organ_name:units = "unitless - string" ;
+		fates_alloc_organ_name:long_name = "Name of plant organs (with alloc_organ_id, must match PRTGenericMod.F90)" ;
+	char fates_hydro_organ_name(fates_hydr_organs, fates_string_length) ;
+		fates_hydro_organ_name:units = "unitless - string" ;
+		fates_hydro_organ_name:long_name = "Name of plant hydraulics organs (DONT CHANGE, order matches media list in FatesHydraulicsMemMod.F90)" ;
+	double fates_alloc_organ_priority(fates_plant_organs, fates_pft) ;
+		fates_alloc_organ_priority:units = "index" ;
+		fates_alloc_organ_priority:long_name = "Priority level for allocation, 1: replaces turnover from storage, 2: same priority as storage use/replacement, 3: ascending in order of least importance" ;
+	double fates_cnp_turnover_nitr_retrans(fates_plant_organs, fates_pft) ;
+		fates_cnp_turnover_nitr_retrans:units = "fraction" ;
+		fates_cnp_turnover_nitr_retrans:long_name = "retranslocation (reabsorbtion) fraction of nitrogen in turnover of scenescing tissues" ;
+	double fates_cnp_turnover_phos_retrans(fates_plant_organs, fates_pft) ;
+		fates_cnp_turnover_phos_retrans:units = "fraction" ;
+		fates_cnp_turnover_phos_retrans:long_name = "retranslocation (reabsorbtion) fraction of phosphorus in turnover of scenescing tissues" ;
+	double fates_hydro_avuln_node(fates_hydr_organs, fates_pft) ;
+		fates_hydro_avuln_node:units = "unitless" ;
+		fates_hydro_avuln_node:long_name = "xylem vulnerability curve shape parameter" ;
+	double fates_hydro_epsil_node(fates_hydr_organs, fates_pft) ;
+		fates_hydro_epsil_node:units = "MPa" ;
+		fates_hydro_epsil_node:long_name = "bulk elastic modulus" ;
+	double fates_hydro_fcap_node(fates_hydr_organs, fates_pft) ;
+		fates_hydro_fcap_node:units = "unitless" ;
+		fates_hydro_fcap_node:long_name = "fraction of non-residual water that is capillary in source" ;
+	double fates_hydro_kmax_node(fates_hydr_organs, fates_pft) ;
+		fates_hydro_kmax_node:units = "kg/MPa/m/s" ;
+		fates_hydro_kmax_node:long_name = "maximum xylem conductivity per unit conducting xylem area" ;
+	double fates_hydro_p50_node(fates_hydr_organs, fates_pft) ;
+		fates_hydro_p50_node:units = "MPa" ;
+		fates_hydro_p50_node:long_name = "xylem water potential at 50% loss of conductivity" ;
+	double fates_hydro_pinot_node(fates_hydr_organs, fates_pft) ;
+		fates_hydro_pinot_node:units = "MPa" ;
+		fates_hydro_pinot_node:long_name = "osmotic potential at full turgor" ;
+	double fates_hydro_pitlp_node(fates_hydr_organs, fates_pft) ;
+		fates_hydro_pitlp_node:units = "MPa" ;
+		fates_hydro_pitlp_node:long_name = "turgor loss point" ;
+	double fates_hydro_resid_node(fates_hydr_organs, fates_pft) ;
+		fates_hydro_resid_node:units = "cm3/cm3" ;
+		fates_hydro_resid_node:long_name = "residual water conent" ;
+	double fates_hydro_thetas_node(fates_hydr_organs, fates_pft) ;
+		fates_hydro_thetas_node:units = "cm3/cm3" ;
+		fates_hydro_thetas_node:long_name = "saturated water content" ;
+	double fates_hydro_vg_alpha_node(fates_hydr_organs, fates_pft) ;
+		fates_hydro_vg_alpha_node:units = "MPa-1" ;
+		fates_hydro_vg_alpha_node:long_name = "(used if hydr_htftype_node = 2), capillary length parameter in van Genuchten model" ;
+	double fates_hydro_vg_m_node(fates_hydr_organs, fates_pft) ;
+		fates_hydro_vg_m_node:units = "unitless" ;
+		fates_hydro_vg_m_node:long_name = "(used if hydr_htftype_node = 2),m in van Genuchten 1980 model, 2nd pore size distribution parameter" ;
+	double fates_hydro_vg_n_node(fates_hydr_organs, fates_pft) ;
+		fates_hydro_vg_n_node:units = "unitless" ;
+		fates_hydro_vg_n_node:long_name = "(used if hydr_htftype_node = 2),n in van Genuchten 1980 model, pore size distribution parameter" ;
+	double fates_stoich_nitr(fates_plant_organs, fates_pft) ;
+		fates_stoich_nitr:units = "gN/gC" ;
+		fates_stoich_nitr:long_name = "target nitrogen concentration (ratio with carbon) of organs" ;
+	double fates_stoich_phos(fates_plant_organs, fates_pft) ;
+		fates_stoich_phos:units = "gP/gC" ;
+		fates_stoich_phos:long_name = "target phosphorus concentration (ratio with carbon) of organs" ;
+	double fates_alloc_organ_id(fates_plant_organs) ;
+		fates_alloc_organ_id:units = "unitless" ;
+		fates_alloc_organ_id:long_name = "This is the global index that the organ in this file is associated with, values match those in parteh/PRTGenericMod.F90" ;
+	double fates_frag_cwd_frac(fates_NCWD) ;
+		fates_frag_cwd_frac:units = "fraction" ;
+		fates_frag_cwd_frac:long_name = "fraction of woody (bdead+bsw) biomass destined for CWD pool" ;
+	double fates_hydro_htftype_node(fates_hydr_organs) ;
+		fates_hydro_htftype_node:units = "unitless" ;
+		fates_hydro_htftype_node:long_name = "Switch that defines the hydraulic transfer functions for each organ." ;
+	double fates_history_coageclass_bin_edges(fates_history_coage_bins) ;
+		fates_history_coageclass_bin_edges:units = "years" ;
+		fates_history_coageclass_bin_edges:long_name = "Lower edges for cohort age class bins used in cohort age resolved history output" ;
+	double fates_history_damage_bin_edges(fates_history_damage_bins) ;
+		fates_history_damage_bin_edges:units = "% crown loss" ;
+		fates_history_damage_bin_edges:long_name = "Lower edges for damage class bins used in cohort history output" ;
+	double fates_leaf_vcmax25top(fates_leafage_class, fates_pft) ;
+		fates_leaf_vcmax25top:units = "umol CO2/m^2/s" ;
+		fates_leaf_vcmax25top:long_name = "maximum carboxylation rate of Rub. at 25C, canopy top" ;
+	double fates_turnover_leaf_canopy(fates_leafage_class, fates_pft) ;
+		fates_turnover_leaf_canopy:units = "yr" ;
+		fates_turnover_leaf_canopy:long_name = "Leaf longevity (ie turnover timescale) of canopy plants. For drought-deciduous PFTs, this also indicates the maximum length of the growing (i.e., leaves on) season." ;
+	double fates_turnover_leaf_ustory(fates_leafage_class, fates_pft) ;
+		fates_turnover_leaf_ustory:units = "yr" ;
+		fates_turnover_leaf_ustory:long_name = "Leaf longevity (ie turnover timescale) of understory plants." ;
 	double fates_canopy_closure_thresh ;
 		fates_canopy_closure_thresh:units = "unitless" ;
 		fates_canopy_closure_thresh:long_name = "tree canopy coverage at which crown area allometry changes from savanna to forest value" ;
@@ -959,25 +959,10 @@ variables:
 		fates_vai_width_increase_factor:long_name = "factor by which each leaf+stem scattering element increases in VAI width (1 = uniform spacing)" ;
 
 // global attributes:
-		:history = "This file was generated by BatchPatchParams.py:\n",
-			"CDL Base File = fates_params_default.cdl\n",
-			"XML patch file = archive/api36.1.0_100224_pr1255-2.xml" ;
+		:history = "This file was made from FatesPFTIndexSwapper.py \n",
+			" Input File = fates_params_default.nc \n",
+			" Indices = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 13]" ;
 data:
-
- fates_history_ageclass_bin_edges = 0, 1, 2, 5, 10, 20, 50 ;
-
- fates_history_coageclass_bin_edges = 0, 5 ;
-
- fates_history_height_bin_edges = 0, 0.1, 0.3, 1, 3, 10 ;
-
- fates_history_damage_bin_edges = 0, 80 ;
-
- fates_history_sizeclass_bin_edges = 0, 5, 10, 15, 20, 30, 40, 50, 60, 70, 
-    80, 90, 100 ;
-
- fates_alloc_organ_id = 1, 2, 3, 6 ;
-
- fates_hydro_htftype_node = 1, 1, 1, 1 ;
 
  fates_pftname =
   "broadleaf_evergreen_tropical_tree          ",
@@ -993,26 +978,599 @@ data:
   " broadleaf_colddecid_arctic_shrub                           ",
   "arctic_c3_grass                            ",
   "cool_c3_grass                              ",
-  "c4_grass                                   " ;
+  "c4_grass                                   ",
+  "cool_c3_grass                              " ;
 
- fates_hydro_organ_name =
-  "leaf                                             ",
-  "stem                                             ",
-  "transporting root                                ",
-  "absorbing root                                   " ;
+ fates_alloc_storage_cushion = 3.4, 2.4, 2.4, 2.4, 2.4, 3.4, 2.4, 2.4, 2.4, 
+    2.4, 2.4, 2.4, 2.4, 2.4, 2.4 ;
 
- fates_alloc_organ_name =
-  "leaf",
-  "fine root",
-  "sapwood",
-  "structure" ;
+ fates_alloc_store_priority_frac = 0.4, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 
+    0.8, 0.7, 0.6, 0.3, 0.3, 0.01, 0.3 ;
 
- fates_landuseclass_name =
-  "primaryland",
-  "secondaryland",
-  "rangeland",
-  "pastureland",
-  "cropland" ;
+ fates_allom_agb1 = 0.0673, 0.01581217, 0.0421922, 0.1375641, 0.0673, 
+    0.0803825, 0.06896, 0.06896, 0.06896, 0.06896, 0.06896, 0.001, 0.001, 
+    0.003, 0.001 ;
+
+ fates_allom_agb2 = 0.976, 1.109661, 1.0761814, 0.8956504, 0.976, 1.0221543, 
+    0.572, 0.572, 0.572, 0.5289883, 0.6853945, 1.6592, 1.6592, 1.3456, 1.6592 ;
+
+ fates_allom_agb3 = 1.94, 1.94, 1.94, 1.94, 1.94, 1.94, 1.94, 1.94, 1.94, 
+    2.1010352, 1.7628613, 1.248, 1.248, 1.869, 1.248 ;
+
+ fates_allom_agb4 = 0.931, 0.931, 0.931, 0.931, 0.931, 0.931, 0.931, 0.931, 
+    0.931, 0.931, 0.931, -999.9, -999.9, -999.9, -999.9 ;
+
+ fates_allom_agb_frac = 0.6, 0.7, 0.8, 0.6, 0.6, 0.6, 0.6, 0.6, 0.6, 0.5, 
+    0.4, 0.5, 1, 1, 1 ;
+
+ fates_allom_amode = 3, 3, 3, 3, 3, 3, 1, 1, 1, 1, 1, 5, 5, 5, 5 ;
+
+ fates_allom_blca_expnt_diff = -0.12, -0.25, -0.32, -0.22, -0.12, -0.35, 0, 
+    0, 0, 0, 0, -0.487, -0.487, -0.259, -0.487 ;
+
+ fates_allom_cmode = 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ;
+
+ fates_allom_d2bl1 = 0.04, 0.025, 0.05, 0.01, 0.04, 0.07, 0.07, 0.07, 0.05, 
+    0.018, 0.018, 0.018, 0.04, 0.04, 0.04 ;
+
+ fates_allom_d2bl2 = 1.6019679, 1.5234373, 1.3051237, 1.9621397, 1.6019679, 
+    1.3998939, 1.3, 1.3, 1.3, 1.0600586, 1.7176758, 1.7092, 1.7092, 1.5879, 
+    1.7092 ;
+
+ fates_allom_d2bl3 = 0.55, 0.55, 0.55, 0.55, 0.55, 0.55, 0.55, 0.55, 0.55, 
+    0.55, 0.55, 0.3417, 0.3417, 0.9948, 0.3417 ;
+
+ fates_allom_d2ca_coefficient_max = 0.2715891, 0.3693718, 1.0787259, 
+    0.0579297, 0.2715891, 1.1553612, 0.6568464, 0.6568464, 0.6568464, 
+    0.4363427, 0.3166497, 0.3, 0.25, 0.15, 0.25 ;
+
+ fates_allom_d2ca_coefficient_min = 0.2715891, 0.3693718, 1.0787259, 
+    0.0579297, 0.2715891, 1.1553612, 0.6568464, 0.6568464, 0.6568464, 
+    0.4363427, 0.3166497, 0.3, 0.25, 0.15, 0.25 ;
+
+ fates_allom_d2h1 = 78.4087704, 306.842667, 106.8745821, 104.3586841, 
+    78.4087704, 31.4557047, 0.64, 0.64, 0.64, 0.8165625, 0.778125, 0.1812, 
+    0.1812, 0.3353, 0.1812 ;
+
+ fates_allom_d2h2 = 0.8124383, 0.752377, 0.9471302, 1.1146973, 0.8124383, 
+    0.9734088, 0.37, 0.37, 0.37, 0.2316113, 0.4027002, 0.6384, 0.6384, 
+    0.4235, 0.6384 ;
+
+ fates_allom_d2h3 = 47.6666164, 196.6865691, 93.9790461, 160.6835089, 
+    47.6666164, 16.5928174, -999.9, -999.9, -999.9, -999.9, -999.9, -999.9, 
+    -999.9, -999.9, -999.9 ;
+
+ fates_allom_dbh_maxheight = 1000, 1000, 1000, 1000, 1000, 1000, 3, 3, 2, 
+    2.4, 1.9, 20, 20, 30, 20 ;
+
+ fates_allom_dmode = 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ;
+
+ fates_allom_fmode = 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ;
+
+ fates_allom_fnrt_prof_a = 7, 7, 7, 7, 6, 6, 7, 7, 7, 7, 7, 11, 11, 11, 11 ;
+
+ fates_allom_fnrt_prof_b = 0.511, 2, 2, 1, 2, 2, 1.5, 1.5, 1.5, 1.5, 1.5, 
+    2.29, 2, 2, 2 ;
+
+ fates_allom_fnrt_prof_mode = 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3 ;
+
+ fates_allom_frbstor_repro = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ;
+
+ fates_allom_h2cd1 = 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.95, 0.95, 0.95, 0.95, 
+    0.95, 1, 1, 1, 1 ;
+
+ fates_allom_h2cd2 = 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ;
+
+ fates_allom_hmode = 5, 5, 5, 5, 5, 5, 1, 1, 1, 1, 1, 3, 3, 3, 3 ;
+
+ fates_allom_l2fr = 1.5, 0.75, 1, 1, 1, 1, 1, 0.7, 0.7, 0.75, 1.4, 1.5, 1.5, 
+    2.3, 1.5 ;
+
+ fates_allom_la_per_sa_int = 0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 
+    0.8, 0.8, 0.8, 0.8, 0.8, 0.8 ;
+
+ fates_allom_la_per_sa_slp = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ;
+
+ fates_allom_lmode = 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 5, 5, 5, 5 ;
+
+ fates_allom_sai_scaler = 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 
+    0.1, 0.1, 0.1, 0.1, 0.1 ;
+
+ fates_allom_smode = 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2 ;
+
+ fates_allom_stmode = 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ;
+
+ fates_allom_zroot_k = 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 
+    10, 10 ;
+
+ fates_allom_zroot_max_dbh = 100, 100, 100, 100, 100, 100, 2, 2, 2, 2, 2, 2, 
+    2, 2, 2 ;
+
+ fates_allom_zroot_max_z = 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 
+    100, 100, 100, 100, 100 ;
+
+ fates_allom_zroot_min_dbh = 1, 1, 1, 2.5, 2.5, 2.5, 0.1, 0.1, 0.1, 0.1, 0.1, 
+    0.1, 0.1, 0.1, 0.1 ;
+
+ fates_allom_zroot_min_z = 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 
+    100, 100, 100, 100, 100 ;
+
+ fates_c2b = 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2 ;
+
+ fates_cnp_eca_alpha_ptase = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ;
+
+ fates_cnp_eca_decompmicc = 280, 280, 280, 280, 280, 280, 280, 280, 280, 280, 
+    280, 280, 280, 280, 280 ;
+
+ fates_cnp_eca_km_nh4 = 0.14, 0.14, 0.14, 0.14, 0.14, 0.14, 0.14, 0.14, 0.14, 
+    0.14, 0.14, 0.14, 0.14, 0.14, 0.14 ;
+
+ fates_cnp_eca_km_no3 = 0.27, 0.27, 0.27, 0.27, 0.27, 0.27, 0.27, 0.27, 0.27, 
+    0.27, 0.27, 0.27, 0.27, 0.27, 0.27 ;
+
+ fates_cnp_eca_km_p = 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 
+    0.1, 0.1, 0.1, 0.1 ;
+
+ fates_cnp_eca_km_ptase = 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ;
+
+ fates_cnp_eca_lambda_ptase = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ;
+
+ fates_cnp_eca_vmax_ptase = 5e-09, 5e-09, 5e-09, 5e-09, 5e-09, 5e-09, 5e-09, 
+    5e-09, 5e-09, 5e-09, 5e-09, 5e-09, 5e-09, 5e-09, 5e-09 ;
+
+ fates_cnp_nfix1 = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ;
+
+ fates_cnp_nitr_store_ratio = 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 
+    1.5, 1.5, 1.5, 1.5, 1.5, 1.5 ;
+
+ fates_cnp_phos_store_ratio = 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 
+    1.5, 1.5, 1.5, 1.5, 1.5, 1.5 ;
+
+ fates_cnp_pid_kd = 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 
+    0.1, 0.1, 0.1, 0.1 ;
+
+ fates_cnp_pid_ki = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ;
+
+ fates_cnp_pid_kp = 0.0005, 0.0005, 0.0005, 0.0005, 0.0005, 0.0005, 0.0005, 
+    0.0005, 0.0005, 0.0005, 0.0005, 0.0005, 0.0005, 0.0005, 0.0005 ;
+
+ fates_cnp_prescribed_nuptake = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ;
+
+ fates_cnp_prescribed_puptake = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ;
+
+ fates_cnp_store_ovrflw_frac = 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ;
+
+ fates_cnp_vmax_nh4 = 2.5e-09, 2.5e-09, 2.5e-09, 2.5e-09, 2.5e-09, 2.5e-09, 
+    2.5e-09, 2.5e-09, 2.5e-09, 2.5e-09, 2.5e-09, 2.5e-09, 2.5e-09, 2.5e-09, 
+    2.5e-09 ;
+
+ fates_cnp_vmax_no3 = 2.5e-09, 2.5e-09, 2.5e-09, 2.5e-09, 2.5e-09, 2.5e-09, 
+    2.5e-09, 2.5e-09, 2.5e-09, 2.5e-09, 2.5e-09, 2.5e-09, 2.5e-09, 2.5e-09, 
+    2.5e-09 ;
+
+ fates_cnp_vmax_p = 5e-10, 5e-10, 5e-10, 5e-10, 5e-10, 5e-10, 5e-10, 5e-10, 
+    5e-10, 5e-10, 5e-10, 5e-10, 5e-10, 5e-10, 5e-10 ;
+
+ fates_damage_frac = 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 
+    0.01, 0.01, 0.01, 0.01, 0.01, 0.01 ;
+
+ fates_damage_mort_p1 = 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9 ;
+
+ fates_damage_mort_p2 = 5.5, 5.5, 5.5, 5.5, 5.5, 5.5, 5.5, 5.5, 5.5, 5.5, 
+    5.5, 5.5, 5.5, 5.5, 5.5 ;
+
+ fates_damage_recovery_scalar = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ;
+
+ fates_dev_arbitrary_pft = _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ ;
+
+ fates_fire_alpha_SH = 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 
+    0.2, 0.2, 0.2, 0.2 ;
+
+ fates_fire_bark_scaler = 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 
+    0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07 ;
+
+ fates_fire_crown_kill = 0.775, 0.775, 0.775, 0.775, 0.775, 0.775, 0.775, 
+    0.775, 0.775, 0.775, 0.775, 0.775, 0.775, 0.775, 0.775 ;
+
+ fates_frag_fnrt_fcel = 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 
+    0.5, 0.5, 0.5, 0.5, 0.5 ;
+
+ fates_frag_fnrt_flab = 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 
+    0.25, 0.25, 0.25, 0.25, 0.25, 0.25 ;
+
+ fates_frag_fnrt_flig = 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 
+    0.25, 0.25, 0.25, 0.25, 0.25, 0.25 ;
+
+ fates_frag_leaf_fcel = 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 
+    0.5, 0.5, 0.5, 0.5, 0.5 ;
+
+ fates_frag_leaf_flab = 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 
+    0.25, 0.25, 0.25, 0.25, 0.25, 0.25 ;
+
+ fates_frag_leaf_flig = 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 
+    0.25, 0.25, 0.25, 0.25, 0.25, 0.25 ;
+
+ fates_frag_seed_decay_rate = 0.51, 0.25, 0.25, 0.51, 0.51, 0.51, 0.51, 0.51, 
+    0.51, 0.51, 0.51, 0.51, 0.51, 0.51, 0.51 ;
+
+ fates_grperc = 0.35, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 
+    0.25, 0.25, 0.25, 0.25, 0.25 ;
+
+ fates_hydro_avuln_gs = 2.5, 2.5, 2.5, 2.5, 2.5, 2.5, 2.5, 2.5, 2.5, 2.5, 
+    2.5, 2.5, 2.5, 2.5, 2.5 ;
+
+ fates_hydro_k_lwp = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ;
+
+ fates_hydro_p50_gs = -1.5, -1.5, -1.5, -1.5, -1.5, -1.5, -1.5, -1.5, -1.5, 
+    -1.5, -1.5, -1.5, -1.5, -1.5, -1.5 ;
+
+ fates_hydro_p_taper = 0.333, 0.333, 0.333, 0.333, 0.333, 0.333, 0.333, 
+    0.333, 0.333, 0.333, 0.333, 0.333, 0.333, 0.333, 0.333 ;
+
+ fates_hydro_rfrac_stem = 0.625, 0.625, 0.625, 0.625, 0.625, 0.625, 0.625, 
+    0.625, 0.625, 0.625, 0.625, 0.625, 0.625, 0.625, 0.625 ;
+
+ fates_hydro_rs2 = 0.0001, 0.0001, 0.0001, 0.0001, 0.0001, 0.0001, 0.0001, 
+    0.0001, 0.0001, 0.0001, 0.0001, 0.0001, 0.0001, 0.0001, 0.0001 ;
+
+ fates_hydro_srl = 25, 25, 25, 25, 25, 25, 25, 25, 25, 25, 25, 25, 25, 25, 25 ;
+
+ fates_init_seed = 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 
+    0.01, 0.01, 0.01, 0.01, 0.01, 0.01 ;
+
+ fates_landuse_grazing_palatability = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.3, 1, 1, 
+    1, 1, 1 ;
+
+ fates_landuse_harvest_pprod10 = 1, 0.75, 0.75, 0.75, 1, 0.75, 1, 1, 1, 1, 1, 
+    1, 1, 1, 1 ;
+
+ fates_landuse_luc_frac_burned = 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 
+    0.5, 0.5, 0.5, 0.5, 0.5, 0.5 ;
+
+ fates_landuse_luc_frac_exported = 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.2, 0.2, 
+    0.2, 0.2, 0.2, 0, 0, 0, 0 ;
+
+ fates_landuse_luc_pprod10 = 1, 0.75, 0.75, 0.75, 1, 0.75, 1, 1, 1, 1, 1, 1, 
+    1, 1, 1 ;
+
+ fates_leaf_agross_btran_model = 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ;
+
+ fates_leaf_c3psn = 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1 ;
+
+ fates_leaf_fnps = 0.19, 0.3, 0.05, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 
+    0.15, 0.15, 0.15, 0.15, 0.15 ;
+
+ fates_leaf_jmaxha = 43540, 43540, 43540, 43540, 43540, 43540, 43540, 43540, 
+    43540, 43540, 43540, 43540, 43540, 43540, 43540 ;
+
+ fates_leaf_jmaxhd = 152040, 152040, 152040, 152040, 152040, 152040, 152040, 
+    152040, 152040, 152040, 152040, 152040, 152040, 152040, 152040 ;
+
+ fates_leaf_jmaxse = 495, 495, 495, 495, 495, 495, 495, 495, 495, 495, 495, 
+    495, 495, 495, 495 ;
+
+ fates_leaf_slamax = 0.03, 0.03, 0.025, 0.03, 0.05, 0.05, 0.012, 0.03, 0.03, 
+    0.012, 0.032, 0.05, 0.05, 0.05, 0.05 ;
+
+ fates_leaf_slatop = 0.024, 0.01, 0.028, 0.024, 0.02, 0.028, 0.012, 0.03, 
+    0.03, 0.01, 0.023, 0.025, 0.03, 0.035, 0.03 ;
+
+ fates_leaf_stomatal_btran_model = 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 1 ;
+
+ fates_leaf_stomatal_intercept = 27443.3, 12943.3, 428.75, 26779.681, 
+    12869.022, 6205.777, 10000, 10000, 3750.669, 10000, 20000, 100.05, 
+    118331.9, 20000, 118331.9 ;
+
+ fates_leaf_stomatal_slope_ballberry = 10, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 
+    8, 8, 8 ;
+
+ fates_leaf_stomatal_slope_medlyn = 3.25, 1.806, 3.812, 4.038, 3.159, 4.7, 
+    4.7, 4.7, 2.503, 4.7, 4.7, 2.32, 7.6, 0.967, 7.6 ;
+
+ fates_leaf_vcmaxha = 65330, 65330, 65330, 65330, 65330, 65330, 65330, 65330, 
+    65330, 65330, 65330, 65330, 65330, 65330, 65330 ;
+
+ fates_leaf_vcmaxhd = 149250, 149250, 149250, 149250, 149250, 149250, 149250, 
+    149250, 149250, 149250, 149250, 149250, 149250, 149250, 149250 ;
+
+ fates_leaf_vcmaxse = 485, 485, 485, 485, 485, 485, 485, 485, 485, 485, 485, 
+    485, 485, 485, 485 ;
+
+ fates_leafn_vert_scaler_coeff1 = 0.0079, 0.014, 0.0048, 0.00963, 0.00963, 
+    0.00963, 0.00963, 0.00963, 0.00963, 0.00963, 0.00963, 0.00963, 0.00963, 
+    0.00963, 0.00963 ;
+
+ fates_leafn_vert_scaler_coeff2 = 1.357, 1.412, 1.23, 2.43, 2.43, 2.43, 2.43, 
+    2.43, 2.43, 2.43, 2.43, 1.82, 2.607, 2.43, 2.607 ;
+
+ fates_maintresp_leaf_atkin2017_baserate = 1.734, 2.169, 2.104, 2.104, 2.069, 
+    1.622, 2.0749, 2.0749, 2.0749, 2.0749, 2.0749, 2.079, 2.0749, 2.182, 
+    2.0749 ;
+
+ fates_maintresp_leaf_ryan1991_baserate = 2.525e-06, 2.525e-06, 2.525e-06, 
+    2.525e-06, 2.525e-06, 2.525e-06, 2.525e-06, 2.525e-06, 2.525e-06, 
+    2.525e-06, 2.525e-06, 2.525e-06, 2.525e-06, 2.525e-06, 2.525e-06 ;
+
+ fates_maintresp_leaf_vert_scaler_coeff1 = 0.00963, 0.00963, 0.00963, 
+    0.00963, 0.00963, 0.00963, 0.00963, 0.00963, 0.00963, 0.00963, 0.00963, 
+    0.00963, 0.00963, 0.00963, 0.00963 ;
+
+ fates_maintresp_leaf_vert_scaler_coeff2 = 2.43, 2.43, 2.43, 2.43, 2.43, 
+    2.43, 2.43, 2.43, 2.43, 2.43, 2.43, 2.43, 2.43, 2.25, 2.43 ;
+
+ fates_maintresp_reduction_curvature = 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 
+    0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01 ;
+
+ fates_maintresp_reduction_intercept = 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 
+    1, 1 ;
+
+ fates_maintresp_reduction_upthresh = 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 
+    1, 1 ;
+
+ fates_mort_bmort = 0.004, 0.02, 0.02, 0.004, 0.004, 0.004, 0.004, 0.004, 
+    0.004, 0.004, 0.004, 0.014, 0.014, 0.05, 0.014 ;
+
+ fates_mort_freezetol = 2.5, -55, -80, -30, 2.5, -80, -60, -10, -80, -71, 
+    -95, -89, -20, 2.5, -20 ;
+
+ fates_mort_hf_flc_threshold = 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 
+    0.5, 0.5, 0.5, 0.5, 0.5, 0.5 ;
+
+ fates_mort_hf_sm_threshold = 0.5, 0.4, 0.4, 0.4, 0.1, 0.4, 0.1, 0.1, 0.1, 
+    0.1, 0.2, 0.2, 0.03, 0.03, 0.03 ;
+
+ fates_mort_ip_age_senescence = _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ ;
+
+ fates_mort_ip_size_senescence = 140, 155, 175, 175, 140, 135, 175, _, _, _, 
+    _, _, _, _, _ ;
+
+ fates_mort_prescribed_canopy = 0.0194, 0.0194, 0.0194, 0.0194, 0.0194, 
+    0.0194, 0.0194, 0.0194, 0.0194, 0.0194, 0.0194, 0.0194, 0.0194, 0.0194, 
+    0.0194 ;
+
+ fates_mort_prescribed_understory = 0.025, 0.025, 0.025, 0.025, 0.025, 0.025, 
+    0.025, 0.025, 0.025, 0.025, 0.025, 0.025, 0.025, 0.025, 0.025 ;
+
+ fates_mort_r_age_senescence = _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ ;
+
+ fates_mort_r_size_senescence = 0.055, 0.055, 0.04, 0.04, 0.055, 0.055, 0.04, 
+    0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04 ;
+
+ fates_mort_scalar_coldstress = 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 
+    0.1, 0.1, 0.1, 0.1, 0.1, 0.1 ;
+
+ fates_mort_scalar_cstarvation = 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.1, 
+    0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1 ;
+
+ fates_mort_scalar_hydrfailure = 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 
+    0.1, 0.1, 0.1, 0.1, 0.1, 0.1 ;
+
+ fates_mort_upthresh_cstarvation = 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ;
+
+ fates_nonhydro_smpsc = -177537.967, -352444.342, -214798.413, -307679.665, 
+    -347451.834, -175120.945, -255000, -255000, -134673.93, -255000, -255000, 
+    -317882.916, -200123.906, -360214.919, -200123.906 ;
+
+ fates_nonhydro_smpso = -34844.846, -87067.176, -33560.298, -98998.485, 
+    -98986.971, -33160.364, -66000, -66000, -33137.782, -66000, -66000, 
+    -96187.704, -35291.509, -51250.654, -35291.509 ;
+
+ fates_phen_cold_size_threshold = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ;
+
+ fates_phen_drought_threshold = -152957.4, -152957.4, -152957.4, -152957.4, 
+    -152957.4, -152957.4, -152957.4, -152957.4, -152957.4, -152957.4, 
+    -152957.4, -152957.4, -152957.4, -152957.4, -152957.4 ;
+
+ fates_phen_flush_fraction = _, _, 0.5, _, 0.5, 0.5, _, 0.5, 0.5, _, 0.5, 
+    0.5, 0.5, 0.5, 0.5 ;
+
+ fates_phen_fnrt_drop_fraction = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ;
+
+ fates_phen_leaf_habit = 1, 1, 2, 1, 3, 2, 1, 3, 2, 1, 2, 2, 1, 1, 1 ;
+
+ fates_phen_mindaysoff = 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 
+    100, 100, 100, 100, 100 ;
+
+ fates_phen_moist_threshold = -122365.9, -122365.9, -122365.9, -122365.9, 
+    -122365.9, -122365.9, -122365.9, -122365.9, -122365.9, -122365.9, 
+    -122365.9, -122365.9, -122365.9, -122365.9, -122365.9 ;
+
+ fates_phen_stem_drop_fraction = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ;
+
+ fates_prescribed_npp_canopy = 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 
+    0.4, 0.4, 0.4, 0.4, 0.4, 0.4 ;
+
+ fates_prescribed_npp_understory = 0.03125, 0.03125, 0.03125, 0.03125, 
+    0.03125, 0.03125, 0.03125, 0.03125, 0.03125, 0.03125, 0.03125, 0.03125, 
+    0.03125, 0.03125, 0.03125 ;
+
+ fates_rad_leaf_clumping_index = 1, 1, 0.3, 0.85, 0.85, 0.9, 0.85, 0.9, 0.9, 
+    0.85, 0.9, 0.71, 0.61, 0.75, 0.61 ;
+
+ fates_rad_leaf_rhonir = 0.46, 0.41, 0.39, 0.46, 0.41, 0.41, 0.46, 0.41, 
+    0.41, 0.46, 0.41, 0.28, 0.28, 0.28, 0.28 ;
+
+ fates_rad_leaf_rhovis = 0.11, 0.09, 0.08, 0.11, 0.08, 0.08, 0.11, 0.08, 
+    0.08, 0.11, 0.08, 0.05, 0.05, 0.05, 0.05 ;
+
+ fates_rad_leaf_taunir = 0.33, 0.32, 0.42, 0.33, 0.43, 0.43, 0.33, 0.43, 
+    0.43, 0.33, 0.43, 0.4, 0.4, 0.4, 0.4 ;
+
+ fates_rad_leaf_tauvis = 0.06, 0.04, 0.06, 0.06, 0.06, 0.06, 0.06, 0.06, 
+    0.06, 0.06, 0.06, 0.05, 0.05, 0.05, 0.05 ;
+
+ fates_rad_leaf_xl = 0.32, 0.01, 0.01, 0.32, 0.2, 0.59, 0.32, 0.59, 0.59, 
+    0.32, 0.59, -0.19, -0.196, -0.23, -0.196 ;
+
+ fates_rad_stem_rhonir = 0.49, 0.36, 0.36, 0.49, 0.49, 0.49, 0.49, 0.49, 
+    0.49, 0.49, 0.49, 0.53, 0.53, 0.53, 0.53 ;
+
+ fates_rad_stem_rhovis = 0.21, 0.12, 0.12, 0.21, 0.21, 0.21, 0.21, 0.21, 
+    0.21, 0.21, 0.21, 0.31, 0.31, 0.31, 0.31 ;
+
+ fates_rad_stem_taunir = 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 
+    0.001, 0.001, 0.001, 0.001, 0.25, 0.25, 0.25, 0.25 ;
+
+ fates_rad_stem_tauvis = 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 
+    0.001, 0.001, 0.001, 0.001, 0.12, 0.12, 0.12, 0.12 ;
+
+ fates_recruit_height_min = 1.3, 1.3, 1.3, 1.3, 1.3, 1.3, 0.2, 0.2, 0.2, 0.1, 
+    0.1, 0.1, 0.1, 0.1, 0.1 ;
+
+ fates_recruit_init_density_full_fates = 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 
+    0.2, 0.2, 0.16, 0.2, 0.2, 0.2, 0.2, 0.2 ;
+
+ fates_recruit_init_nocomp = -1, -1, -1, -1, -1, -1, -0.5, -0.5, -0.5, -0.5, 
+    -0.5, -0.1, -0.1, -0.1, -0.1 ;
+
+ fates_recruit_prescribed_rate = 0.02, 0.02, 0.02, 0.02, 0.02, 0.02, 0.02, 
+    0.02, 0.02, 0.02, 0.02, 0.02, 0.02, 0.02, 0.02 ;
+
+ fates_recruit_seed_alloc = 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 
+    0.07, 0.1, 0.1, 0.1, 0.1, 0.1 ;
+
+ fates_recruit_seed_alloc_mature = 0, 0, 0, 0, 0, 0, 0.9, 0.9, 0.9, 0.9, 0.9, 
+    0.25, 0.25, 0.9, 0.25 ;
+
+ fates_recruit_seed_dbh_repro_threshold = 90, 80, 80, 80, 90, 80, 3, 3, 2, 
+    2.4, 1.9, 3, 3, 30, 3 ;
+
+ fates_recruit_seed_germination_rate = 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 
+    0.5, 0.5, 0.4, 0.49, 0.29, 0.5, 0.5, 0.5 ;
+
+ fates_recruit_seed_supplement = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ;
+
+ fates_seed_dispersal_fraction = _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ ;
+
+ fates_seed_dispersal_max_dist = _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ ;
+
+ fates_seed_dispersal_pdf_scale = _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ ;
+
+ fates_seed_dispersal_pdf_shape = _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ ;
+
+ fates_trim_inc = 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 
+    0.03, 0.03, 0.03, 0.03, 0.03 ;
+
+ fates_trim_limit = 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 
+    0.3, 0.3, 0.3, 0.3 ;
+
+ fates_trs_repro_alloc_a = 0.0049, 0.0049, 0.0049, 0.0049, 0.0049, 0.0049, 
+    0.0049, 0.0049, 0.0049, 0.0049, 0.0049, 0.0049, 0.0049, 0.0049, 0.0049 ;
+
+ fates_trs_repro_alloc_b = -2.6171, -2.6171, -2.6171, -2.6171, -2.6171, 
+    -2.6171, -2.6171, -2.6171, -2.6171, -2.6171, -2.6171, -2.6171, -2.6171, 
+    -2.6171, -2.6171 ;
+
+ fates_trs_repro_frac_seed = 0.24, 0.24, 0.24, 0.24, 0.24, 0.24, 0.24, 0.24, 
+    0.24, 0.24, 0.24, 0.24, 0.24, 0.24, 0.24 ;
+
+ fates_trs_seedling_a_emerg = 0.0003, 0.0003, 0.0003, 0.0003, 0.0003, 0.0003, 
+    0.0003, 0.0003, 0.0003, 0.0003, 0.0003, 0.0003, 0.0003, 0.0003, 0.0003 ;
+
+ fates_trs_seedling_b_emerg = 1.2, 1.2, 1.2, 1.2, 1.2, 1.2, 1.2, 1.2, 1.2, 
+    1.2, 1.2, 1.2, 1.2, 1.2, 1.2 ;
+
+ fates_trs_seedling_background_mort = 0.1085371, 0.1085371, 0.1085371, 
+    0.1085371, 0.1085371, 0.1085371, 0.1085371, 0.1085371, 0.1085371, 
+    0.1085371, 0.1085371, 0.1085371, 0.1085371, 0.1085371, 0.1085371 ;
+
+ fates_trs_seedling_h2o_mort_a = 4.070565e-17, 4.070565e-17, 4.070565e-17, 
+    4.070565e-17, 4.070565e-17, 4.070565e-17, 4.070565e-17, 4.070565e-17, 
+    4.070565e-17, 4.070565e-17, 4.070565e-17, 4.070565e-17, 4.070565e-17, 
+    4.070565e-17, 4.070565e-17 ;
+
+ fates_trs_seedling_h2o_mort_b = -6.390757e-11, -6.390757e-11, -6.390757e-11, 
+    -6.390757e-11, -6.390757e-11, -6.390757e-11, -6.390757e-11, 
+    -6.390757e-11, -6.390757e-11, -6.390757e-11, -6.390757e-11, 
+    -6.390757e-11, -6.390757e-11, -6.390757e-11, -6.390757e-11 ;
+
+ fates_trs_seedling_h2o_mort_c = 1.268992e-05, 1.268992e-05, 1.268992e-05, 
+    1.268992e-05, 1.268992e-05, 1.268992e-05, 1.268992e-05, 1.268992e-05, 
+    1.268992e-05, 1.268992e-05, 1.268992e-05, 1.268992e-05, 1.268992e-05, 
+    1.268992e-05, 1.268992e-05 ;
+
+ fates_trs_seedling_light_mort_a = -0.009897694, -0.009897694, -0.009897694, 
+    -0.009897694, -0.009897694, -0.009897694, -0.009897694, -0.009897694, 
+    -0.009897694, -0.009897694, -0.009897694, -0.009897694, -0.009897694, 
+    -0.009897694, -0.009897694 ;
+
+ fates_trs_seedling_light_mort_b = -7.154063, -7.154063, -7.154063, 
+    -7.154063, -7.154063, -7.154063, -7.154063, -7.154063, -7.154063, 
+    -7.154063, -7.154063, -7.154063, -7.154063, -7.154063, -7.154063 ;
+
+ fates_trs_seedling_light_rec_a = 0.007, 0.007, 0.007, 0.007, 0.007, 0.007, 
+    0.007, 0.007, 0.007, 0.007, 0.007, 0.007, 0.007, 0.007, 0.007 ;
+
+ fates_trs_seedling_light_rec_b = 0.8615, 0.8615, 0.8615, 0.8615, 0.8615, 
+    0.8615, 0.8615, 0.8615, 0.8615, 0.8615, 0.8615, 0.8615, 0.8615, 0.8615, 
+    0.8615 ;
+
+ fates_trs_seedling_mdd_crit = 1400000, 1400000, 1400000, 1400000, 1400000, 
+    1400000, 1400000, 1400000, 1400000, 1400000, 1400000, 1400000, 1400000, 
+    1400000, 1400000 ;
+
+ fates_trs_seedling_par_crit_germ = 0.656, 0.656, 0.656, 0.656, 0.656, 0.656, 
+    0.656, 0.656, 0.656, 0.656, 0.656, 0.656, 0.656, 0.656, 0.656 ;
+
+ fates_trs_seedling_psi_crit = -251995.7, -251995.7, -251995.7, -251995.7, 
+    -251995.7, -251995.7, -251995.7, -251995.7, -251995.7, -251995.7, 
+    -251995.7, -251995.7, -251995.7, -251995.7, -251995.7 ;
+
+ fates_trs_seedling_psi_emerg = -15744.65, -15744.65, -15744.65, -15744.65, 
+    -15744.65, -15744.65, -15744.65, -15744.65, -15744.65, -15744.65, 
+    -15744.65, -15744.65, -15744.65, -15744.65, -15744.65 ;
+
+ fates_trs_seedling_root_depth = 0.06, 0.06, 0.06, 0.06, 0.06, 0.06, 0.06, 
+    0.06, 0.06, 0.06, 0.06, 0.06, 0.06, 0.06, 0.06 ;
+
+ fates_turb_displar = 0.056, 0.67, 0.67, 0.67, 0.67, 0.67, 0.67, 0.67, 0.67, 
+    0.67, 0.67, 0.67, 0.67, 0.67, 0.67 ;
+
+ fates_turb_leaf_diameter = 0.031, 0.0298, 0.00072, 0.04, 0.04, 0.04, 0.04, 
+    0.04, 0.04, 0.04, 0.04, 0.027, 0.033, 0.04, 0.033 ;
+
+ fates_turb_z0mr = 0.06, 0.077, 0.033, 0.075, 0.055, 0.055, 0.12, 0.12, 0.12, 
+    0.12, 0.12, 0.126, 0.078, 0.12, 0.078 ;
+
+ fates_turnover_branch = 150, 150, 150, 150, 150, 150, 150, 150, 150, 150, 
+    150, 0, 0, 0, 0 ;
+
+ fates_turnover_fnrt = 1, 2, 2, 1.5, 1, 1, 1, 1, 3, 1.5, 1, 1, 0.75, 0.5, 0.75 ;
+
+ fates_turnover_senleaf_fdrought = 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ;
+
+ fates_voc_pftindex = 4, 1, 3, 5, 6, 7, 9, 10, 10, 9, 11, 12, 13, 14, 13 ;
+
+ fates_wesley_pft_index_fordrydep = 4, 5, 5, 4, 4, 4, 11, 11, 11, 3, 3, 3, 3, 
+    3, 3 ;
+
+ fates_wood_density = 0.548327, 0.434, 0.454845, 0.754336, 0.548327, 
+    0.566452, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7 ;
+
+ fates_woody = 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0 ;
+
+ fates_hlm_pft_map =
+  0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0.1, 0.1, 0.8, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0 ;
+
+ fates_history_sizeclass_bin_edges = 0, 5, 10, 15, 20, 30, 40, 50, 60, 70, 
+    80, 90, 100 ;
+
+ fates_history_ageclass_bin_edges = 0, 1, 2, 5, 10, 20, 50 ;
 
  fates_litterclass_name =
   "twig                                             ",
@@ -1022,735 +1580,9 @@ data:
   "dead leaves                                      ",
   "live grass                                       " ;
 
- fates_alloc_organ_priority =
-  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-  2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-  3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-  4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4 ;
-
- fates_alloc_storage_cushion = 3.4, 2.4, 2.4, 2.4, 2.4, 3.4, 2.4, 2.4, 2.4, 
-    2.4, 2.4, 2.4, 2.4, 2.4 ;
-
- fates_alloc_store_priority_frac = 0.4, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 
-    0.8, 0.7, 0.6, 0.3, 0.3, 0.01 ;
-
- fates_allom_agb1 = 0.0673, 0.01581217, 0.0421922, 0.1375641, 0.0673, 
-    0.0803825, 0.06896, 0.06896, 0.06896, 0.06896, 0.06896, 0.001, 0.001, 
-    0.003 ;
-
- fates_allom_agb2 = 0.976, 1.109661, 1.0761814, 0.8956504, 0.976, 1.0221543,
- 0.572, 0.572, 0.572, 0.5289883, 0.6853945, 1.6592, 1.6592, 1.3456 ;
-
- fates_allom_agb3 = 1.94, 1.94, 1.94, 1.94, 1.94, 1.94, 1.94, 1.94, 1.94, 
-    2.1010352, 1.7628613, 1.248, 1.248, 1.869 ;
-
- fates_allom_agb4 = 0.931, 0.931, 0.931, 0.931, 0.931, 0.931, 0.931, 0.931, 
-    0.931, 0.931, 0.931, -999.9, -999.9, -999.9 ;
-
- fates_allom_agb_frac = 0.6, 0.7, 0.8, 0.6, 0.6, 0.6, 0.6, 0.6, 0.6, 0.5, 
-    0.4, 0.5, 1, 1 ;
-
- fates_allom_amode = 3, 3, 3, 3, 3, 3, 1, 1, 1, 1, 1, 5, 5, 5 ;
-
- fates_allom_blca_expnt_diff = -0.12, -0.25, -0.32, -0.22, -0.12, -0.35, 0, 
-    0, 0, 0, 0, -0.487, -0.487, -0.259 ;
-
- fates_allom_cmode = 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ;
-
- fates_allom_d2bl1 = 0.04, 0.025, 0.05, 0.01, 0.04, 0.07, 0.07, 0.07, 0.05, 
-    0.018, 0.018, 0.018, 0.04, 0.04 ;
-
- fates_allom_d2bl2 = 1.6019679, 1.5234373, 1.3051237, 1.9621397, 1.6019679, 
-    1.3998939, 1.3, 1.3, 1.3, 1.0600586, 1.7176758, 1.7092, 1.7092, 1.5879 ;
-
- fates_allom_d2bl3 = 0.55, 0.55, 0.55, 0.55, 0.55, 0.55, 0.55, 0.55, 0.55, 
-    0.55, 0.55, 0.3417, 0.3417, 0.9948 ;
-
- fates_allom_d2ca_coefficient_max = 0.2715891, 0.3693718, 1.0787259, 
-    0.0579297, 0.2715891, 1.1553612, 0.6568464, 0.6568464, 0.6568464, 
-    0.4363427, 0.3166497, 0.3, 0.25, 0.15 ;
-
- fates_allom_d2ca_coefficient_min = 0.2715891, 0.3693718, 1.0787259, 
-    0.0579297, 0.2715891, 1.1553612, 0.6568464, 0.6568464, 0.6568464, 
-    0.4363427, 0.3166497, 0.3, 0.25, 0.15 ;
-
- fates_allom_d2h1 = 78.4087704, 306.842667, 106.8745821, 104.3586841, 
-    78.4087704, 31.4557047, 0.64, 0.64, 0.64, 0.8165625, 0.778125, 0.1812, 
-    0.1812, 0.3353 ;
-
- fates_allom_d2h2 = 0.8124383, 0.752377, 0.9471302, 1.1146973, 0.8124383, 
-    0.9734088, 0.37, 0.37, 0.37, 0.2316113, 0.4027002, 0.6384, 0.6384, 0.4235 ;
-
- fates_allom_d2h3 = 47.6666164, 196.6865691, 93.9790461, 160.6835089, 
-    47.6666164, 16.5928174, -999.9, -999.9, -999.9, -999.9, -999.9, -999.9, 
-    -999.9, -999.9 ;
-
- fates_allom_dbh_maxheight = 1000, 1000, 1000, 1000, 1000, 1000, 3, 3, 2, 
-    2.4, 1.9, 20, 20, 30 ;
-
- fates_allom_dmode = 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ;
-
- fates_allom_fmode = 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ;
-
- fates_allom_fnrt_prof_a = 7, 7, 7, 7, 6, 6, 7, 7, 7, 7, 7, 11, 11, 11 ;
-
- fates_allom_fnrt_prof_b = 0.511, 2, 2, 1, 2, 2, 1.5, 1.5, 1.5, 1.5, 1.5, 
-    2.29, 2, 2 ;
-
- fates_allom_fnrt_prof_mode = 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3 ;
-
- fates_allom_frbstor_repro = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ;
-
- fates_allom_h2cd1 = 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.95, 0.95, 0.95, 0.95, 
-    0.95, 1, 1, 1 ;
-
- fates_allom_h2cd2 = 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ;
-
- fates_allom_hmode = 5, 5, 5, 5, 5, 5, 1, 1, 1, 1, 1, 3, 3, 3 ;
-
- fates_allom_l2fr = 1.5, 0.75, 1, 1, 1, 1, 1, 0.7, 0.7, 0.75, 1.4, 1.5, 1.5, 
-    2.3 ;
-
- fates_allom_la_per_sa_int = 0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 
-    0.8, 0.8, 0.8, 0.8, 0.8 ;
-
- fates_allom_la_per_sa_slp = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ;
-
- fates_allom_lmode = 2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 5, 5, 5 ;
-
- fates_allom_sai_scaler = 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 
-    0.1, 0.1, 0.1, 0.1 ;
-
- fates_allom_smode = 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2 ;
-
- fates_allom_stmode = 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ;
-
- fates_allom_zroot_k = 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10 ;
-
- fates_allom_zroot_max_dbh = 100, 100, 100, 100, 100, 100, 2, 2, 2, 2, 2, 2, 
-    2, 2 ;
-
- fates_allom_zroot_max_z = 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 
-    100, 100, 100, 100 ;
-
- fates_allom_zroot_min_dbh = 1, 1, 1, 2.5, 2.5, 2.5, 0.1, 0.1, 0.1, 0.1, 0.1, 
-    0.1, 0.1, 0.1 ;
-
- fates_allom_zroot_min_z = 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 
-    100, 100, 100, 100 ;
-
- fates_c2b = 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2 ;
-
- fates_cnp_eca_alpha_ptase = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ;
-
- fates_cnp_eca_decompmicc = 280, 280, 280, 280, 280, 280, 280, 280, 280, 280, 
-    280, 280, 280, 280 ;
-
- fates_cnp_eca_km_nh4 = 0.14, 0.14, 0.14, 0.14, 0.14, 0.14, 0.14, 0.14, 0.14, 
-    0.14, 0.14, 0.14, 0.14, 0.14 ;
-
- fates_cnp_eca_km_no3 = 0.27, 0.27, 0.27, 0.27, 0.27, 0.27, 0.27, 0.27, 0.27, 
-    0.27, 0.27, 0.27, 0.27, 0.27 ;
-
- fates_cnp_eca_km_p = 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 
-    0.1, 0.1, 0.1 ;
-
- fates_cnp_eca_km_ptase = 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ;
-
- fates_cnp_eca_lambda_ptase = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ;
-
- fates_cnp_eca_vmax_ptase = 5e-09, 5e-09, 5e-09, 5e-09, 5e-09, 5e-09, 5e-09, 
-    5e-09, 5e-09, 5e-09, 5e-09, 5e-09, 5e-09, 5e-09 ;
-
- fates_cnp_nfix1 = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ;
-
- fates_cnp_nitr_store_ratio = 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 
-    1.5, 1.5, 1.5, 1.5, 1.5 ;
-
- fates_cnp_phos_store_ratio = 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 
-    1.5, 1.5, 1.5, 1.5, 1.5 ;
-
- fates_cnp_pid_kd = 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 
-    0.1, 0.1, 0.1 ;
-
- fates_cnp_pid_ki = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ;
-
- fates_cnp_pid_kp = 0.0005, 0.0005, 0.0005, 0.0005, 0.0005, 0.0005, 0.0005, 
-    0.0005, 0.0005, 0.0005, 0.0005, 0.0005, 0.0005, 0.0005 ;
-
- fates_cnp_prescribed_nuptake = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ;
-
- fates_cnp_prescribed_puptake = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ;
-
- fates_cnp_store_ovrflw_frac = 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ;
-
- fates_cnp_turnover_nitr_retrans =
-  0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 
-    0.25, 0.25,
-  0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 
-    0.25, 0.25,
-  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ;
-
- fates_cnp_turnover_phos_retrans =
-  0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 
-    0.25, 0.25,
-  0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 
-    0.25, 0.25,
-  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ;
-
- fates_cnp_vmax_nh4 = 2.5e-09, 2.5e-09, 2.5e-09, 2.5e-09, 2.5e-09, 2.5e-09, 
-    2.5e-09, 2.5e-09, 2.5e-09, 2.5e-09, 2.5e-09, 2.5e-09, 2.5e-09, 2.5e-09 ;
-
- fates_cnp_vmax_no3 = 2.5e-09, 2.5e-09, 2.5e-09, 2.5e-09, 2.5e-09, 2.5e-09, 
-    2.5e-09, 2.5e-09, 2.5e-09, 2.5e-09, 2.5e-09, 2.5e-09, 2.5e-09, 2.5e-09 ;
-
- fates_cnp_vmax_p = 5e-10, 5e-10, 5e-10, 5e-10, 5e-10, 5e-10, 5e-10, 5e-10, 
-    5e-10, 5e-10, 5e-10, 5e-10, 5e-10, 5e-10 ;
-
- fates_damage_frac = 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 
-    0.01, 0.01, 0.01, 0.01, 0.01 ;
-
- fates_damage_mort_p1 = 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9 ;
-
- fates_damage_mort_p2 = 5.5, 5.5, 5.5, 5.5, 5.5, 5.5, 5.5, 5.5, 5.5, 5.5, 
-    5.5, 5.5, 5.5, 5.5 ;
-
- fates_damage_recovery_scalar = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ;
-
- fates_dev_arbitrary_pft = _, _, _, _, _, _, _, _, _, _, _, _, _, _ ;
-
- fates_fire_alpha_SH = 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 
-    0.2, 0.2, 0.2 ;
-
- fates_fire_bark_scaler = 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 0.07, 
-    0.07, 0.07, 0.07, 0.07, 0.07, 0.07 ;
-
- fates_fire_crown_kill = 0.775, 0.775, 0.775, 0.775, 0.775, 0.775, 0.775, 
-    0.775, 0.775, 0.775, 0.775, 0.775, 0.775, 0.775 ;
-
- fates_frag_fnrt_fcel = 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 
-    0.5, 0.5, 0.5, 0.5 ;
-
- fates_frag_fnrt_flab = 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 
-    0.25, 0.25, 0.25, 0.25, 0.25 ;
-
- fates_frag_fnrt_flig = 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 
-    0.25, 0.25, 0.25, 0.25, 0.25 ;
-
- fates_frag_leaf_fcel = 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 
-    0.5, 0.5, 0.5, 0.5 ;
-
- fates_frag_leaf_flab = 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 
-    0.25, 0.25, 0.25, 0.25, 0.25 ;
-
- fates_frag_leaf_flig = 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 
-    0.25, 0.25, 0.25, 0.25, 0.25 ;
-
- fates_frag_seed_decay_rate = 0.51, 0.25, 0.25, 0.51, 0.51, 0.51, 0.51, 0.51, 
-    0.51, 0.51, 0.51, 0.51, 0.51, 0.51 ;
-
- fates_grperc = 0.35, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 
-    0.25, 0.25, 0.25, 0.25 ;
-
- fates_hydro_avuln_gs = 2.5, 2.5, 2.5, 2.5, 2.5, 2.5, 2.5, 2.5, 2.5, 2.5, 
-    2.5, 2.5, 2.5, 2.5 ;
-
- fates_hydro_avuln_node =
-  2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-  2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-  2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-  2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2 ;
-
- fates_hydro_epsil_node =
-  12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12,
-  10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10,
-  10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10,
-  8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8 ;
-
- fates_hydro_fcap_node =
-  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-  0.08, 0.08, 0.08, 0.08, 0.08, 0.08, 0.08, 0.08, 0.08, 0.08, 0.08, 0.08, 
-    0.08, 0.08,
-  0.08, 0.08, 0.08, 0.08, 0.08, 0.08, 0.08, 0.08, 0.08, 0.08, 0.08, 0.08, 
-    0.08, 0.08,
-  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ;
-
- fates_hydro_k_lwp = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ;
-
- fates_hydro_kmax_node =
-  -999, -999, -999, -999, -999, -999, -999, -999, -999, -999, -999, -999, 
-    -999, -999,
-  3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-  -999, -999, -999, -999, -999, -999, -999, -999, -999, -999, -999, -999, 
-    -999, -999,
-  -999, -999, -999, -999, -999, -999, -999, -999, -999, -999, -999, -999, 
-    -999, -999 ;
-
- fates_hydro_p50_gs = -1.5, -1.5, -1.5, -1.5, -1.5, -1.5, -1.5, -1.5, -1.5, 
-    -1.5, -1.5, -1.5, -1.5, -1.5 ;
-
- fates_hydro_p50_node =
-  -2.25, -2.25, -2.25, -2.25, -2.25, -2.25, -2.25, -2.25, -2.25, -2.25, 
-    -2.25, -2.25, -2.25, -2.25,
-  -2.25, -2.25, -2.25, -2.25, -2.25, -2.25, -2.25, -2.25, -2.25, -2.25, 
-    -2.25, -2.25, -2.25, -2.25,
-  -2.25, -2.25, -2.25, -2.25, -2.25, -2.25, -2.25, -2.25, -2.25, -2.25, 
-    -2.25, -2.25, -2.25, -2.25,
-  -2.25, -2.25, -2.25, -2.25, -2.25, -2.25, -2.25, -2.25, -2.25, -2.25, 
-    -2.25, -2.25, -2.25, -2.25 ;
-
- fates_hydro_p_taper = 0.333, 0.333, 0.333, 0.333, 0.333, 0.333, 0.333, 
-    0.333, 0.333, 0.333, 0.333, 0.333, 0.333, 0.333 ;
-
- fates_hydro_pinot_node =
-  -1.465984, -1.465984, -1.465984, -1.465984, -1.465984, -1.465984, 
-    -1.465984, -1.465984, -1.465984, -1.465984, -1.465984, -1.465984, 
-    -1.465984, -1.465984,
-  -1.22807, -1.22807, -1.22807, -1.22807, -1.22807, -1.22807, -1.22807, 
-    -1.22807, -1.22807, -1.22807, -1.22807, -1.22807, -1.22807, -1.22807,
-  -1.22807, -1.22807, -1.22807, -1.22807, -1.22807, -1.22807, -1.22807, 
-    -1.22807, -1.22807, -1.22807, -1.22807, -1.22807, -1.22807, -1.22807,
-  -1.043478, -1.043478, -1.043478, -1.043478, -1.043478, -1.043478, 
-    -1.043478, -1.043478, -1.043478, -1.043478, -1.043478, -1.043478, 
-    -1.043478, -1.043478 ;
-
- fates_hydro_pitlp_node =
-  -1.67, -1.67, -1.67, -1.67, -1.67, -1.67, -1.67, -1.67, -1.67, -1.67, 
-    -1.67, -1.67, -1.67, -1.67,
-  -1.4, -1.4, -1.4, -1.4, -1.4, -1.4, -1.4, -1.4, -1.4, -1.4, -1.4, -1.4, 
-    -1.4, -1.4,
-  -1.4, -1.4, -1.4, -1.4, -1.4, -1.4, -1.4, -1.4, -1.4, -1.4, -1.4, -1.4, 
-    -1.4, -1.4,
-  -1.2, -1.2, -1.2, -1.2, -1.2, -1.2, -1.2, -1.2, -1.2, -1.2, -1.2, -1.2, 
-    -1.2, -1.2 ;
-
- fates_hydro_resid_node =
-  0.16, 0.16, 0.16, 0.16, 0.16, 0.16, 0.16, 0.16, 0.16, 0.16, 0.16, 0.16, 
-    0.16, 0.16,
-  0.21, 0.21, 0.21, 0.21, 0.21, 0.21, 0.21, 0.21, 0.21, 0.21, 0.21, 0.21, 
-    0.21, 0.21,
-  0.21, 0.21, 0.21, 0.21, 0.21, 0.21, 0.21, 0.21, 0.21, 0.21, 0.21, 0.21, 
-    0.21, 0.21,
-  0.11, 0.11, 0.11, 0.11, 0.11, 0.11, 0.11, 0.11, 0.11, 0.11, 0.11, 0.11, 
-    0.11, 0.11 ;
-
- fates_hydro_rfrac_stem = 0.625, 0.625, 0.625, 0.625, 0.625, 0.625, 0.625, 
-    0.625, 0.625, 0.625, 0.625, 0.625, 0.625, 0.625 ;
-
- fates_hydro_rs2 = 0.0001, 0.0001, 0.0001, 0.0001, 0.0001, 0.0001, 0.0001, 
-    0.0001, 0.0001, 0.0001, 0.0001, 0.0001, 0.0001, 0.0001 ;
-
- fates_hydro_srl = 25, 25, 25, 25, 25, 25, 25, 25, 25, 25, 25, 25, 25, 25 ;
-
- fates_hydro_thetas_node =
-  0.65, 0.65, 0.65, 0.65, 0.65, 0.65, 0.65, 0.65, 0.65, 0.65, 0.65, 0.65, 
-    0.65, 0.65,
-  0.65, 0.65, 0.65, 0.65, 0.65, 0.65, 0.65, 0.65, 0.65, 0.65, 0.65, 0.65, 
-    0.65, 0.65,
-  0.65, 0.65, 0.65, 0.65, 0.65, 0.65, 0.65, 0.65, 0.65, 0.65, 0.65, 0.65, 
-    0.65, 0.65,
-  0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 
-    0.75, 0.75 ;
-
- fates_hydro_vg_alpha_node =
-  0.0005, 0.0005, 0.0005, 0.0005, 0.0005, 0.005, 0.005, 0.005, 0.005, 0.005, 
-    0.005, 0.005, 0.005, 0.005,
-  0.0005, 0.0005, 0.0005, 0.0005, 0.0005, 0.005, 0.005, 0.005, 0.005, 0.005, 
-    0.005, 0.005, 0.005, 0.005,
-  0.0005, 0.0005, 0.0005, 0.0005, 0.0005, 0.005, 0.005, 0.005, 0.005, 0.005, 
-    0.005, 0.005, 0.005, 0.005,
-  0.0005, 0.0005, 0.0005, 0.0005, 0.0005, 0.005, 0.005, 0.005, 0.005, 0.005, 
-    0.005, 0.005, 0.005, 0.005 ;
-
- fates_hydro_vg_m_node =
-  0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5,
-  0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5,
-  0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5,
-  0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5 ;
-
- fates_hydro_vg_n_node =
-  2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-  2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-  2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-  2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2 ;
-
- fates_landuse_grazing_palatability = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.3, 1, 1, 
-    1, 1 ;
-
- fates_landuse_harvest_pprod10 = 1, 0.75, 0.75, 0.75, 1, 0.75, 1, 1, 1, 1, 1, 
-    1, 1, 1 ;
-
- fates_landuse_luc_frac_burned = 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 
-    0.5, 0.5, 0.5, 0.5, 0.5 ;
-
- fates_landuse_luc_frac_exported = 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.2, 0.2, 
-    0.2, 0.2, 0.2, 0, 0, 0 ;
-
- fates_landuse_luc_pprod10 = 1, 0.75, 0.75, 0.75, 1, 0.75, 1, 1, 1, 1, 1, 1, 
-    1, 1 ;
-
- fates_leaf_agross_btran_model = 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ;
-
- fates_leaf_c3psn = 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 ;
-
- fates_leaf_fnps = 0.19, 0.3, 0.05, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 
-    0.15, 0.15, 0.15, 0.15 ;
-
- fates_leaf_jmaxha = 43540, 43540, 43540, 43540, 43540, 43540, 43540, 43540, 
-    43540, 43540, 43540, 43540, 43540, 43540 ;
-
- fates_leaf_jmaxhd = 152040, 152040, 152040, 152040, 152040, 152040, 152040, 
-    152040, 152040, 152040, 152040, 152040, 152040, 152040 ;
-
- fates_leaf_jmaxse = 495, 495, 495, 495, 495, 495, 495, 495, 495, 495, 495, 
-    495, 495, 495 ;
-
- fates_leaf_slamax = 0.03, 0.03, 0.025, 0.03, 0.05, 0.05, 0.012, 0.03, 0.03, 
-    0.012, 0.032, 0.05, 0.05, 0.05 ;
-
- fates_leaf_slatop = 0.024, 0.01, 0.028, 0.024, 0.02, 0.028, 0.012, 0.03, 
-    0.03, 0.01, 0.023, 0.025, 0.03, 0.035 ;
-
- fates_leaf_stomatal_btran_model = 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3 ;
-
- fates_leaf_stomatal_intercept = 27443.3, 12943.3, 428.75, 26779.681, 
-    12869.022, 6205.777, 10000, 10000, 3750.669, 10000, 20000, 100.05, 
-    118331.9, 20000 ;
-
- fates_leaf_stomatal_slope_ballberry = 10, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 
-    8, 8 ;
-
- fates_leaf_stomatal_slope_medlyn = 3.25, 1.806, 3.812, 4.038, 3.159, 4.7, 
-    4.7, 4.7, 2.503, 4.7, 4.7, 2.32, 7.6, 0.967 ;
-
- fates_leaf_vcmax25top =
-  47.59, 40.91, 45, 40, 38.393, 52, 62, 54, 53.712, 40, 50, 42.55, 69.17, 
-    17.955 ;
-
- fates_leaf_vcmaxha = 65330, 65330, 65330, 65330, 65330, 65330, 65330, 65330, 
-    65330, 65330, 65330, 65330, 65330, 65330 ;
-
- fates_leaf_vcmaxhd = 149250, 149250, 149250, 149250, 149250, 149250, 149250, 
-    149250, 149250, 149250, 149250, 149250, 149250, 149250 ;
-
- fates_leaf_vcmaxse = 485, 485, 485, 485, 485, 485, 485, 485, 485, 485, 485, 
-    485, 485, 485 ;
-
- fates_leafn_vert_scaler_coeff1 = 0.0079, 0.014, 0.0048, 0.00963, 0.00963, 
-    0.00963, 0.00963, 0.00963, 0.00963, 0.00963, 0.00963, 0.00963, 0.00963, 
-    0.00963 ;
-
- fates_leafn_vert_scaler_coeff2 = 1.357, 1.412, 1.23, 2.43, 2.43, 2.43, 2.43, 
-    2.43, 2.43, 2.43, 2.43, 1.82, 2.607, 2.43 ;
-
- fates_maintresp_leaf_atkin2017_baserate = 1.734, 2.169, 2.104, 2.104, 2.069, 
-    1.622, 2.0749, 2.0749, 2.0749, 2.0749, 2.0749, 2.079, 2.0749, 2.182 ;
-
- fates_maintresp_leaf_ryan1991_baserate = 2.525e-06, 2.525e-06, 2.525e-06, 
-    2.525e-06, 2.525e-06, 2.525e-06, 2.525e-06, 2.525e-06, 2.525e-06, 
-    2.525e-06, 2.525e-06, 2.525e-06, 2.525e-06, 2.525e-06 ;
-
- fates_maintresp_leaf_vert_scaler_coeff1 = 0.00963, 0.00963, 0.00963, 
-    0.00963, 0.00963, 0.00963, 0.00963, 0.00963, 0.00963, 0.00963, 0.00963, 
-    0.00963, 0.00963, 0.00963 ;
-
- fates_maintresp_leaf_vert_scaler_coeff2 = 2.43, 2.43, 2.43, 2.43, 2.43, 
-    2.43, 2.43, 2.43, 2.43, 2.43, 2.43, 2.43, 2.43, 2.25 ;
-
- fates_maintresp_reduction_curvature = 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 
-    0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01 ;
-
- fates_maintresp_reduction_intercept = 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ;
-
- fates_maintresp_reduction_upthresh = 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ;
-
- fates_mort_bmort = 0.004, 0.02, 0.02, 0.004, 0.004, 0.004, 0.004, 0.004, 
-    0.004, 0.004, 0.004, 0.014, 0.014, 0.05 ;
-
- fates_mort_freezetol = 2.5, -55, -80, -30, 2.5, -80, -60, -10, -80, -71, 
-    -95, -89, -20, 2.5 ;
-
- fates_mort_hf_flc_threshold = 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 
-    0.5, 0.5, 0.5, 0.5, 0.5 ;
-
- fates_mort_hf_sm_threshold = 0.5, 0.4, 0.4, 0.4, 0.1, 0.4, 0.1, 0.1, 0.1, 
-    0.1, 0.2, 0.2, 0.03, 0.03 ;
-
- fates_mort_ip_age_senescence = _, _, _, _, _, _, _, _, _, _, _, _, _, _ ;
-
- fates_mort_ip_size_senescence = 140, 155, 175, 175, 140, 135, 175, _, _, _, 
-    _, _, _, _ ;
-
- fates_mort_prescribed_canopy = 0.0194, 0.0194, 0.0194, 0.0194, 0.0194, 
-    0.0194, 0.0194, 0.0194, 0.0194, 0.0194, 0.0194, 0.0194, 0.0194, 0.0194 ;
-
- fates_mort_prescribed_understory = 0.025, 0.025, 0.025, 0.025, 0.025, 0.025, 
-    0.025, 0.025, 0.025, 0.025, 0.025, 0.025, 0.025, 0.025 ;
-
- fates_mort_r_age_senescence = _, _, _, _, _, _, _, _, _, _, _, _, _, _ ;
-
- fates_mort_r_size_senescence = 0.055, 0.055, 0.04, 0.04, 0.055, 0.055, 0.04, 
-    0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04 ;
-
- fates_mort_scalar_coldstress = 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 
-    0.1, 0.1, 0.1, 0.1, 0.1 ;
-
- fates_mort_scalar_cstarvation = 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.1, 
-    0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1 ;
-
- fates_mort_scalar_hydrfailure = 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 
-    0.1, 0.1, 0.1, 0.1, 0.1 ;
-
- fates_mort_upthresh_cstarvation = 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ;
-
- fates_nonhydro_smpsc = -177537.967, -352444.342, -214798.413, -307679.665, 
-    -347451.834, -175120.945, -255000, -255000, -134673.93, -255000, -255000, 
-    -317882.916, -200123.906, -360214.919 ;
-
- fates_nonhydro_smpso = -34844.846, -87067.176, -33560.298, -98998.485, 
-    -98986.971, -33160.364, -66000, -66000, -33137.782, -66000, -66000, 
-    -96187.704, -35291.509, -51250.654 ;
-
- fates_phen_cold_size_threshold = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ;
-
- fates_phen_drought_threshold = -152957.4, -152957.4, -152957.4, -152957.4, 
-    -152957.4, -152957.4, -152957.4, -152957.4, -152957.4, -152957.4, 
-    -152957.4, -152957.4, -152957.4, -152957.4 ;
-
- fates_phen_flush_fraction = _, _, 0.5, _, 0.5, 0.5, _, 0.5, 0.5, _, 0.5, 
-    0.5, 0.5, 0.5 ;
-
- fates_phen_fnrt_drop_fraction = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ;
-
- fates_phen_leaf_habit = 1, 1, 2, 1, 3, 2, 1, 3, 2, 1, 2, 2, 1, 1 ;
-
- fates_phen_mindaysoff = 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 
-    100, 100, 100, 100 ;
-
- fates_phen_moist_threshold = -122365.9, -122365.9, -122365.9, -122365.9, 
-    -122365.9, -122365.9, -122365.9, -122365.9, -122365.9, -122365.9, 
-    -122365.9, -122365.9, -122365.9, -122365.9 ;
-
- fates_phen_stem_drop_fraction = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ;
-
- fates_prescribed_npp_canopy = 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 
-    0.4, 0.4, 0.4, 0.4, 0.4 ;
-
- fates_prescribed_npp_understory = 0.03125, 0.03125, 0.03125, 0.03125, 
-    0.03125, 0.03125, 0.03125, 0.03125, 0.03125, 0.03125, 0.03125, 0.03125, 
-    0.03125, 0.03125 ;
-
- fates_rad_leaf_clumping_index = 1, 1, 0.3, 0.85, 0.85, 0.9, 0.85, 0.9, 0.9, 
-    0.85, 0.9, 0.71, 0.61, 0.75 ;
-
- fates_rad_leaf_rhonir = 0.46, 0.41, 0.39, 0.46, 0.41, 0.41, 0.46, 0.41, 
-    0.41, 0.46, 0.41, 0.28, 0.28, 0.28 ;
-
- fates_rad_leaf_rhovis = 0.11, 0.09, 0.08, 0.11, 0.08, 0.08, 0.11, 0.08, 
-    0.08, 0.11, 0.08, 0.05, 0.05, 0.05 ;
-
- fates_rad_leaf_taunir = 0.33, 0.32, 0.42, 0.33, 0.43, 0.43, 0.33, 0.43, 
-    0.43, 0.33, 0.43, 0.4, 0.4, 0.4 ;
-
- fates_rad_leaf_tauvis = 0.06, 0.04, 0.06, 0.06, 0.06, 0.06, 0.06, 0.06, 
-    0.06, 0.06, 0.06, 0.05, 0.05, 0.05 ;
-
- fates_rad_leaf_xl = 0.32, 0.01, 0.01, 0.32, 0.2, 0.59, 0.32, 0.59, 0.59, 
-    0.32, 0.59, -0.19, -0.196, -0.23 ;
-
- fates_rad_stem_rhonir = 0.49, 0.36, 0.36, 0.49, 0.49, 0.49, 0.49, 0.49, 
-    0.49, 0.49, 0.49, 0.53, 0.53, 0.53 ;
-
- fates_rad_stem_rhovis = 0.21, 0.12, 0.12, 0.21, 0.21, 0.21, 0.21, 0.21, 
-    0.21, 0.21, 0.21, 0.31, 0.31, 0.31 ;
-
- fates_rad_stem_taunir = 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 
-    0.001, 0.001, 0.001, 0.001, 0.25, 0.25, 0.25 ;
-
- fates_rad_stem_tauvis = 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 
-    0.001, 0.001, 0.001, 0.001, 0.12, 0.12, 0.12 ;
-
- fates_recruit_height_min = 1.3, 1.3, 1.3, 1.3, 1.3, 1.3, 0.2, 0.2, 0.2, 0.1, 
-    0.1, 0.1, 0.1, 0.1 ;
-
- fates_recruit_init_density_full_fates = 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 
-    0.2, 0.2, 0.16, 0.2, 0.2, 0.2, 0.2 ;
-
- fates_recruit_init_nocomp = -1, -1, -1, -1, -1, -1, -0.5, -0.5, -0.5, -0.5, 
-    -0.5, -0.1, -0.1, -0.1 ;
-
- fates_init_seed = 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 
-    0.01, 0.01, 0.01, 0.01, 0.01 ;
-
- fates_recruit_prescribed_rate = 0.02, 0.02, 0.02, 0.02, 0.02, 0.02, 0.02, 
-    0.02, 0.02, 0.02, 0.02, 0.02, 0.02, 0.02 ;
-
- fates_recruit_seed_alloc = 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 
-    0.07, 0.1, 0.1, 0.1, 0.1 ;
-
- fates_recruit_seed_alloc_mature = 0, 0, 0, 0, 0, 0, 0.9, 0.9, 0.9, 0.9, 0.9, 
-    0.25, 0.25, 0.9 ;
-
- fates_recruit_seed_dbh_repro_threshold = 90, 80, 80, 80, 90, 80, 3, 3, 2, 
-    2.4, 1.9, 3, 3, 30 ;
-
- fates_recruit_seed_germination_rate = 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 
-    0.5, 0.5, 0.4, 0.49, 0.29, 0.5, 0.5 ;
-
- fates_recruit_seed_supplement = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ;
-
- fates_seed_dispersal_fraction = _, _, _, _, _, _, _, _, _, _, _, _, _, _ ;
-
- fates_seed_dispersal_max_dist = _, _, _, _, _, _, _, _, _, _, _, _, _, _ ;
-
- fates_seed_dispersal_pdf_scale = _, _, _, _, _, _, _, _, _, _, _, _, _, _ ;
-
- fates_seed_dispersal_pdf_shape = _, _, _, _, _, _, _, _, _, _, _, _, _, _ ;
-
- fates_stoich_nitr =
-  0.033, 0.029, 0.04, 0.033, 0.04, 0.04, 0.033, 0.04, 0.04, 0.033, 0.04, 
-    0.04, 0.04, 0.04,
-  0.024, 0.024, 0.024, 0.024, 0.024, 0.024, 0.024, 0.024, 0.024, 0.024, 
-    0.024, 0.024, 0.024, 0.024,
-  1e-08, 1e-08, 1e-08, 1e-08, 1e-08, 1e-08, 1e-08, 1e-08, 1e-08, 1e-08, 
-    1e-08, 1e-08, 1e-08, 1e-08,
-  0.0047, 0.0047, 0.0047, 0.0047, 0.0047, 0.0047, 0.0047, 0.0047, 0.0047, 
-    0.0047, 0.0047, 0.0047, 0.0047, 0.0047 ;
-
- fates_stoich_phos =
-  0.0033, 0.0029, 0.004, 0.0033, 0.004, 0.004, 0.0033, 0.004, 0.004, 0.0033, 
-    0.004, 0.004, 0.004, 0.004,
-  0.0024, 0.0024, 0.0024, 0.0024, 0.0024, 0.0024, 0.0024, 0.0024, 0.0024, 
-    0.0024, 0.0024, 0.0024, 0.0024, 0.0024,
-  1e-09, 1e-09, 1e-09, 1e-09, 1e-09, 1e-09, 1e-09, 1e-09, 1e-09, 1e-09, 
-    1e-09, 1e-09, 1e-09, 1e-09,
-  0.00047, 0.00047, 0.00047, 0.00047, 0.00047, 0.00047, 0.00047, 0.00047, 
-    0.00047, 0.00047, 0.00047, 0.00047, 0.00047, 0.00047 ;
-
- fates_trim_inc = 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 
-    0.03, 0.03, 0.03, 0.03 ;
-
- fates_trim_limit = 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 
-    0.3, 0.3, 0.3 ;
-
- fates_trs_repro_alloc_a = 0.0049, 0.0049, 0.0049, 0.0049, 0.0049, 0.0049, 
-    0.0049, 0.0049, 0.0049, 0.0049, 0.0049, 0.0049, 0.0049, 0.0049 ;
-
- fates_trs_repro_alloc_b = -2.6171, -2.6171, -2.6171, -2.6171, -2.6171, 
-    -2.6171, -2.6171, -2.6171, -2.6171, -2.6171, -2.6171, -2.6171, -2.6171, 
-    -2.6171 ;
-
- fates_trs_repro_frac_seed = 0.24, 0.24, 0.24, 0.24, 0.24, 0.24, 0.24, 0.24, 
-    0.24, 0.24, 0.24, 0.24, 0.24, 0.24 ;
-
- fates_trs_seedling_a_emerg = 0.0003, 0.0003, 0.0003, 0.0003, 0.0003, 0.0003, 
-    0.0003, 0.0003, 0.0003, 0.0003, 0.0003, 0.0003, 0.0003, 0.0003 ;
-
- fates_trs_seedling_b_emerg = 1.2, 1.2, 1.2, 1.2, 1.2, 1.2, 1.2, 1.2, 1.2, 
-    1.2, 1.2, 1.2, 1.2, 1.2 ;
-
- fates_trs_seedling_background_mort = 0.1085371, 0.1085371, 0.1085371, 
-    0.1085371, 0.1085371, 0.1085371, 0.1085371, 0.1085371, 0.1085371, 
-    0.1085371, 0.1085371, 0.1085371, 0.1085371, 0.1085371 ;
-
- fates_trs_seedling_h2o_mort_a = 4.070565e-17, 4.070565e-17, 4.070565e-17, 
-    4.070565e-17, 4.070565e-17, 4.070565e-17, 4.070565e-17, 4.070565e-17, 
-    4.070565e-17, 4.070565e-17, 4.070565e-17, 4.070565e-17, 4.070565e-17, 
-    4.070565e-17 ;
-
- fates_trs_seedling_h2o_mort_b = -6.390757e-11, -6.390757e-11, -6.390757e-11, 
-    -6.390757e-11, -6.390757e-11, -6.390757e-11, -6.390757e-11, 
-    -6.390757e-11, -6.390757e-11, -6.390757e-11, -6.390757e-11, 
-    -6.390757e-11, -6.390757e-11, -6.390757e-11 ;
-
- fates_trs_seedling_h2o_mort_c = 1.268992e-05, 1.268992e-05, 1.268992e-05, 
-    1.268992e-05, 1.268992e-05, 1.268992e-05, 1.268992e-05, 1.268992e-05, 
-    1.268992e-05, 1.268992e-05, 1.268992e-05, 1.268992e-05, 1.268992e-05, 
-    1.268992e-05 ;
-
- fates_trs_seedling_light_mort_a = -0.009897694, -0.009897694, -0.009897694, 
-    -0.009897694, -0.009897694, -0.009897694, -0.009897694, -0.009897694, 
-    -0.009897694, -0.009897694, -0.009897694, -0.009897694, -0.009897694, 
-    -0.009897694 ;
-
- fates_trs_seedling_light_mort_b = -7.154063, -7.154063, -7.154063, 
-    -7.154063, -7.154063, -7.154063, -7.154063, -7.154063, -7.154063, 
-    -7.154063, -7.154063, -7.154063, -7.154063, -7.154063 ;
-
- fates_trs_seedling_light_rec_a = 0.007, 0.007, 0.007, 0.007, 0.007, 0.007, 
-    0.007, 0.007, 0.007, 0.007, 0.007, 0.007, 0.007, 0.007 ;
-
- fates_trs_seedling_light_rec_b = 0.8615, 0.8615, 0.8615, 0.8615, 0.8615, 
-    0.8615, 0.8615, 0.8615, 0.8615, 0.8615, 0.8615, 0.8615, 0.8615, 0.8615 ;
-
- fates_trs_seedling_mdd_crit = 1400000, 1400000, 1400000, 1400000, 1400000, 
-    1400000, 1400000, 1400000, 1400000, 1400000, 1400000, 1400000, 1400000, 
-    1400000 ;
-
- fates_trs_seedling_par_crit_germ = 0.656, 0.656, 0.656, 0.656, 0.656, 0.656, 
-    0.656, 0.656, 0.656, 0.656, 0.656, 0.656, 0.656, 0.656 ;
-
- fates_trs_seedling_psi_crit = -251995.7, -251995.7, -251995.7, -251995.7, 
-    -251995.7, -251995.7, -251995.7, -251995.7, -251995.7, -251995.7, 
-    -251995.7, -251995.7, -251995.7, -251995.7 ;
-
- fates_trs_seedling_psi_emerg = -15744.65, -15744.65, -15744.65, -15744.65, 
-    -15744.65, -15744.65, -15744.65, -15744.65, -15744.65, -15744.65, 
-    -15744.65, -15744.65, -15744.65, -15744.65 ;
-
- fates_trs_seedling_root_depth = 0.06, 0.06, 0.06, 0.06, 0.06, 0.06, 0.06, 
-    0.06, 0.06, 0.06, 0.06, 0.06, 0.06, 0.06 ;
-
- fates_turb_displar = 0.056, 0.67, 0.67, 0.67, 0.67, 0.67, 0.67, 0.67, 0.67, 
-    0.67, 0.67, 0.67, 0.67, 0.67 ;
-
- fates_turb_leaf_diameter = 0.031, 0.0298, 0.00072, 0.04, 0.04, 0.04, 0.04, 
-    0.04, 0.04, 0.04, 0.04, 0.027, 0.033, 0.04 ;
-
- fates_turb_z0mr = 0.06, 0.077, 0.033, 0.075, 0.055, 0.055, 0.12, 0.12, 0.12, 
-    0.12, 0.12, 0.126, 0.078, 0.12 ;
-
- fates_turnover_branch = 150, 150, 150, 150, 150, 150, 150, 150, 150, 150, 
-    150, 0, 0, 0 ;
-
- fates_turnover_fnrt = 1, 2, 2, 1.5, 1, 1, 1, 1, 3, 1.5, 1, 1, 0.75, 0.5 ;
-
- fates_turnover_leaf_canopy =
-  1.5, 3, 1, 1.5, 0.7, 1, 1.5, 1, 1, 1.5, 1, 1, 0.25, 0.25 ;
-
- fates_turnover_leaf_ustory =
-  2.5, 4, 1, 1.5, 1, 1, 1.5, 1, 1, 1.5, 1, 1, 0.2, 0.2 ;
-
- fates_turnover_senleaf_fdrought = 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ;
-
- fates_wood_density = 0.548327, 0.434, 0.454845, 0.754336, 0.548327, 
-    0.566452, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7 ;
-
- fates_woody = 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0 ;
-
- fates_voc_pftindex = 4, 1, 3, 5, 6, 7, 9, 10, 10, 9, 11, 12, 13, 14 ;
-
- fates_hlm_pft_map =
-  0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-  0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-  0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-  1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-  0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-  0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-  0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,
-  0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,
-  0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0,
-  0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0,
-  0, 0, 0, 0, 0, 0, 0, 0, 0.1, 0.1, 0.8, 0, 0, 0,
-  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0,
-  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0,
-  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1;
-
- fates_wesley_pft_index_fordrydep = 4, 5, 5, 4, 4, 4, 11, 11, 11, 3, 3, 3, 3, 3 ;
-
  fates_fire_FBD = 15.4, 16.8, 19.6, 999, 4, 4 ;
+
+ fates_fire_SAV = 13, 3.58, 0.98, 0.2, 66, 66 ;
 
  fates_fire_low_moisture_Coeff = 1.12, 1.09, 0.98, 0.8, 1.15, 1.15 ;
 
@@ -1764,19 +1596,203 @@ data:
 
  fates_fire_min_moisture = 0.18, 0.12, 0, 0, 0.24, 0.24 ;
 
- fates_fire_SAV = 13, 3.58, 0.98, 0.2, 66, 66 ;
-
  fates_frag_maxdecomp = 1, 0.83, 0.383, 0.19, 1, 999 ;
 
- fates_frag_cwd_frac = 0.045, 0.075, 0.21, 0.67 ;
+ fates_history_height_bin_edges = 0, 0.1, 0.3, 1, 3, 10 ;
 
- fates_landuse_crop_lu_pft_vector = -999, -999, -999, -999, 13 ;
+ fates_landuseclass_name =
+  "primaryland",
+  "secondaryland",
+  "rangeland",
+  "pastureland",
+  "cropland" ;
+
+ fates_landuse_crop_lu_pft_vector = -999, -999, -999, -999, 15 ;
 
  fates_landuse_grazing_rate = 0.007, 0, 0.02, 0.02, 0.02 ;
 
  fates_max_nocomp_pfts_by_landuse = 4, 4, 1, 1, 1 ;
 
  fates_maxpatches_by_landuse = 9, 4, 1, 1, 1 ;
+
+ fates_alloc_organ_name =
+  "leaf",
+  "fine root",
+  "sapwood",
+  "structure" ;
+
+ fates_hydro_organ_name =
+  "leaf                                             ",
+  "stem                                             ",
+  "transporting root                                ",
+  "absorbing root                                   " ;
+
+ fates_alloc_organ_priority =
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+  2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+  3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+  4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4 ;
+
+ fates_cnp_turnover_nitr_retrans =
+  0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 
+    0.25, 0.25, 0.25,
+  0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 
+    0.25, 0.25, 0.25,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ;
+
+ fates_cnp_turnover_phos_retrans =
+  0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 
+    0.25, 0.25, 0.25,
+  0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 
+    0.25, 0.25, 0.25,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ;
+
+ fates_hydro_avuln_node =
+  2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+  2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+  2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+  2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2 ;
+
+ fates_hydro_epsil_node =
+  12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12,
+  10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10,
+  10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10,
+  8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8 ;
+
+ fates_hydro_fcap_node =
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0.08, 0.08, 0.08, 0.08, 0.08, 0.08, 0.08, 0.08, 0.08, 0.08, 0.08, 0.08, 
+    0.08, 0.08, 0.08,
+  0.08, 0.08, 0.08, 0.08, 0.08, 0.08, 0.08, 0.08, 0.08, 0.08, 0.08, 0.08, 
+    0.08, 0.08, 0.08,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ;
+
+ fates_hydro_kmax_node =
+  -999, -999, -999, -999, -999, -999, -999, -999, -999, -999, -999, -999, 
+    -999, -999, -999,
+  3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+  -999, -999, -999, -999, -999, -999, -999, -999, -999, -999, -999, -999, 
+    -999, -999, -999,
+  -999, -999, -999, -999, -999, -999, -999, -999, -999, -999, -999, -999, 
+    -999, -999, -999 ;
+
+ fates_hydro_p50_node =
+  -2.25, -2.25, -2.25, -2.25, -2.25, -2.25, -2.25, -2.25, -2.25, -2.25, 
+    -2.25, -2.25, -2.25, -2.25, -2.25,
+  -2.25, -2.25, -2.25, -2.25, -2.25, -2.25, -2.25, -2.25, -2.25, -2.25, 
+    -2.25, -2.25, -2.25, -2.25, -2.25,
+  -2.25, -2.25, -2.25, -2.25, -2.25, -2.25, -2.25, -2.25, -2.25, -2.25, 
+    -2.25, -2.25, -2.25, -2.25, -2.25,
+  -2.25, -2.25, -2.25, -2.25, -2.25, -2.25, -2.25, -2.25, -2.25, -2.25, 
+    -2.25, -2.25, -2.25, -2.25, -2.25 ;
+
+ fates_hydro_pinot_node =
+  -1.465984, -1.465984, -1.465984, -1.465984, -1.465984, -1.465984, 
+    -1.465984, -1.465984, -1.465984, -1.465984, -1.465984, -1.465984, 
+    -1.465984, -1.465984, -1.465984,
+  -1.22807, -1.22807, -1.22807, -1.22807, -1.22807, -1.22807, -1.22807, 
+    -1.22807, -1.22807, -1.22807, -1.22807, -1.22807, -1.22807, -1.22807, 
+    -1.22807,
+  -1.22807, -1.22807, -1.22807, -1.22807, -1.22807, -1.22807, -1.22807, 
+    -1.22807, -1.22807, -1.22807, -1.22807, -1.22807, -1.22807, -1.22807, 
+    -1.22807,
+  -1.043478, -1.043478, -1.043478, -1.043478, -1.043478, -1.043478, 
+    -1.043478, -1.043478, -1.043478, -1.043478, -1.043478, -1.043478, 
+    -1.043478, -1.043478, -1.043478 ;
+
+ fates_hydro_pitlp_node =
+  -1.67, -1.67, -1.67, -1.67, -1.67, -1.67, -1.67, -1.67, -1.67, -1.67, 
+    -1.67, -1.67, -1.67, -1.67, -1.67,
+  -1.4, -1.4, -1.4, -1.4, -1.4, -1.4, -1.4, -1.4, -1.4, -1.4, -1.4, -1.4, 
+    -1.4, -1.4, -1.4,
+  -1.4, -1.4, -1.4, -1.4, -1.4, -1.4, -1.4, -1.4, -1.4, -1.4, -1.4, -1.4, 
+    -1.4, -1.4, -1.4,
+  -1.2, -1.2, -1.2, -1.2, -1.2, -1.2, -1.2, -1.2, -1.2, -1.2, -1.2, -1.2, 
+    -1.2, -1.2, -1.2 ;
+
+ fates_hydro_resid_node =
+  0.16, 0.16, 0.16, 0.16, 0.16, 0.16, 0.16, 0.16, 0.16, 0.16, 0.16, 0.16, 
+    0.16, 0.16, 0.16,
+  0.21, 0.21, 0.21, 0.21, 0.21, 0.21, 0.21, 0.21, 0.21, 0.21, 0.21, 0.21, 
+    0.21, 0.21, 0.21,
+  0.21, 0.21, 0.21, 0.21, 0.21, 0.21, 0.21, 0.21, 0.21, 0.21, 0.21, 0.21, 
+    0.21, 0.21, 0.21,
+  0.11, 0.11, 0.11, 0.11, 0.11, 0.11, 0.11, 0.11, 0.11, 0.11, 0.11, 0.11, 
+    0.11, 0.11, 0.11 ;
+
+ fates_hydro_thetas_node =
+  0.65, 0.65, 0.65, 0.65, 0.65, 0.65, 0.65, 0.65, 0.65, 0.65, 0.65, 0.65, 
+    0.65, 0.65, 0.65,
+  0.65, 0.65, 0.65, 0.65, 0.65, 0.65, 0.65, 0.65, 0.65, 0.65, 0.65, 0.65, 
+    0.65, 0.65, 0.65,
+  0.65, 0.65, 0.65, 0.65, 0.65, 0.65, 0.65, 0.65, 0.65, 0.65, 0.65, 0.65, 
+    0.65, 0.65, 0.65,
+  0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 
+    0.75, 0.75, 0.75 ;
+
+ fates_hydro_vg_alpha_node =
+  0.0005, 0.0005, 0.0005, 0.0005, 0.0005, 0.005, 0.005, 0.005, 0.005, 0.005, 
+    0.005, 0.005, 0.005, 0.005, 0.005,
+  0.0005, 0.0005, 0.0005, 0.0005, 0.0005, 0.005, 0.005, 0.005, 0.005, 0.005, 
+    0.005, 0.005, 0.005, 0.005, 0.005,
+  0.0005, 0.0005, 0.0005, 0.0005, 0.0005, 0.005, 0.005, 0.005, 0.005, 0.005, 
+    0.005, 0.005, 0.005, 0.005, 0.005,
+  0.0005, 0.0005, 0.0005, 0.0005, 0.0005, 0.005, 0.005, 0.005, 0.005, 0.005, 
+    0.005, 0.005, 0.005, 0.005, 0.005 ;
+
+ fates_hydro_vg_m_node =
+  0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5,
+  0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5,
+  0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5,
+  0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5 ;
+
+ fates_hydro_vg_n_node =
+  2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+  2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+  2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+  2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2 ;
+
+ fates_stoich_nitr =
+  0.033, 0.029, 0.04, 0.033, 0.04, 0.04, 0.033, 0.04, 0.04, 0.033, 0.04, 
+    0.04, 0.04, 0.04, 0.04,
+  0.024, 0.024, 0.024, 0.024, 0.024, 0.024, 0.024, 0.024, 0.024, 0.024, 
+    0.024, 0.024, 0.024, 0.024, 0.024,
+  1e-08, 1e-08, 1e-08, 1e-08, 1e-08, 1e-08, 1e-08, 1e-08, 1e-08, 1e-08, 
+    1e-08, 1e-08, 1e-08, 1e-08, 1e-08,
+  0.0047, 0.0047, 0.0047, 0.0047, 0.0047, 0.0047, 0.0047, 0.0047, 0.0047, 
+    0.0047, 0.0047, 0.0047, 0.0047, 0.0047, 0.0047 ;
+
+ fates_stoich_phos =
+  0.0033, 0.0029, 0.004, 0.0033, 0.004, 0.004, 0.0033, 0.004, 0.004, 0.0033, 
+    0.004, 0.004, 0.004, 0.004, 0.004,
+  0.0024, 0.0024, 0.0024, 0.0024, 0.0024, 0.0024, 0.0024, 0.0024, 0.0024, 
+    0.0024, 0.0024, 0.0024, 0.0024, 0.0024, 0.0024,
+  1e-09, 1e-09, 1e-09, 1e-09, 1e-09, 1e-09, 1e-09, 1e-09, 1e-09, 1e-09, 
+    1e-09, 1e-09, 1e-09, 1e-09, 1e-09,
+  0.00047, 0.00047, 0.00047, 0.00047, 0.00047, 0.00047, 0.00047, 0.00047, 
+    0.00047, 0.00047, 0.00047, 0.00047, 0.00047, 0.00047, 0.00047 ;
+
+ fates_alloc_organ_id = 1, 2, 3, 6 ;
+
+ fates_frag_cwd_frac = 0.045, 0.075, 0.21, 0.67 ;
+
+ fates_hydro_htftype_node = 1, 1, 1, 1 ;
+
+ fates_history_coageclass_bin_edges = 0, 5 ;
+
+ fates_history_damage_bin_edges = 0, 80 ;
+
+ fates_leaf_vcmax25top =
+  47.59, 40.91, 45, 40, 38.393, 52, 62, 54, 53.712, 40, 50, 42.55, 69.17, 
+    17.955, 69.17 ;
+
+ fates_turnover_leaf_canopy =
+  1.5, 3, 1, 1.5, 0.7, 1, 1.5, 1, 1, 1.5, 1, 1, 0.25, 0.25, 0.25 ;
+
+ fates_turnover_leaf_ustory =
+  2.5, 4, 1, 1.5, 1, 1, 1.5, 1, 1, 1.5, 1, 1, 0.2, 0.2, 0.2 ;
 
  fates_canopy_closure_thresh = 0.8 ;
 

--- a/parameter_files/fates_params_default.cdl
+++ b/parameter_files/fates_params_default.cdl
@@ -1,4 +1,4 @@
-netcdf fates_params_default_tmp {
+fates_params_sci.1.88.6_api.42.0.0_14pft_nor_sci3_api1_c260209 {
 dimensions:
 	fates_NCWD = 4 ;
 	fates_history_age_bins = 7 ;

--- a/parameter_files/fates_params_default.cdl
+++ b/parameter_files/fates_params_default.cdl
@@ -979,7 +979,7 @@ data:
   "arctic_c3_grass                            ",
   "cool_c3_grass                              ",
   "c4_grass                                   ",
-  "cool_c3_grass                              " ;
+  "crops                              " ;
 
  fates_alloc_storage_cushion = 3.4, 2.4, 2.4, 2.4, 2.4, 3.4, 2.4, 2.4, 2.4, 
     2.4, 2.4, 2.4, 2.4, 2.4, 2.4 ;


### PR DESCRIPTION
### Description:
Combine various changes to parameter file. This brings in changes from [PR #53 ](https://github.com/NorESMhub/fates/pull/53) and also adds the two extra HLM PFTs to go with the 16 hlm PFT surface file. Diff looks much bigger than it is, I think variable order is getting mixed up from FatesPFTIndexSwapper. 




### Collaborators:
@rosiealice 

### Expectation of Answer Changes:


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
Short 5 year test suggests this is working as expected. 
Nocomp PFT area: 
<img width="800" height="369" alt="image" src="https://github.com/user-attachments/assets/db24a47b-1689-40c6-b549-363735da7ed3" />

and PFT GPP: 
<img width="1424" height="657" alt="image" src="https://github.com/user-attachments/assets/e5d0baa0-0dd1-43e7-9a45-ec7fe30ce323" />



<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

