### PR TITLE
revert hlm pfts to 14 - necessary for LU

### DIFF
--- a/parameter_files/fates_params_default.cdl
+++ b/parameter_files/fates_params_default.cdl
@@ -6,7 +6,7 @@ dimensions:
 	fates_history_damage_bins = 2 ;
 	fates_history_height_bins = 6 ;
 	fates_history_size_bins = 13 ;
-	fates_hlm_pftno = 16 ;
+	fates_hlm_pftno = 14 ;
 	fates_hydr_organs = 4 ;
 	fates_landuseclass = 5 ;
 	fates_leafage_class = 1 ;
@@ -1562,8 +1562,6 @@ data:
   0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0.1, 0.1, 0.8, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0,
-  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0,
-  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0 ;
 


### PR DESCRIPTION
This reverses the change to increase HLM pfts. We need them to be 14 to match LU code. 


